### PR TITLE
Cleaning up cluster and s3 bucket on error.

### DIFF
--- a/destroy_ocp4_cluster.yml
+++ b/destroy_ocp4_cluster.yml
@@ -4,6 +4,4 @@
   environment:
     KUBECONFIG: "{{ playbook_dir }}/auth/kubeconfig"
   roles:
-  - login_ocp
-  - ocp4_velero_setup
   - ocp4_cluster_destroy

--- a/pipeline/ocp4-base
+++ b/pipeline/ocp4-base
@@ -113,6 +113,23 @@ node {
         }
         
     } catch (e) {
+        withCredentials([
+            string(credentialsId: "$EC2_ACCESS_KEY_ID", variable: 'AWS_ACCESS_KEY_ID'),
+            string(credentialsId: "$EC2_SECRET_ACCESS_KEY", variable: 'AWS_SECRET_ACCESS_KEY')
+            ]) 
+        {
+            withEnv(['PATH+EXTRA=~/bin']) {
+                dir('mig-ci') {
+                    ansiColor('xterm') {
+                        ansiblePlaybook(
+                            playbook: 'destroy_ocp4_cluster.yml',
+                            hostKeyChecking: false,
+                            unbuffered: true,
+                            colorized: true)
+                    }
+                }
+            }
+        }
         currentBuild.result = "FAILED"
         throw e
     } finally {

--- a/roles/login_ocp/defaults/main.yml
+++ b/roles/login_ocp/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
-oc_binary_location: "{{ ansible_env.HOME }}/bin/"
+oc_binary_location: "{{ ansible_env.HOME }}/bin"
 user: kubeadmin

--- a/roles/login_ocp/defaults/main.yml
+++ b/roles/login_ocp/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 oc_binary_location: "{{ ansible_env.HOME }}/bin/"
-user: admin
+user: kubeadmin

--- a/roles/login_ocp/tasks/main.yml
+++ b/roles/login_ocp/tasks/main.yml
@@ -6,6 +6,10 @@
   vars:
     kubeadmin_password: "{{ lookup('file', '{{ playbook_dir }}/auth/kubeadmin-password') }}"
   shell: "{{ oc_binary_location }}/oc login -u {{ user }} -p {{ kubeadmin_password }}"
+  register: login
+  retries: 10
+  delay: 6
+  until: login.rc == 0
 
 - name: dump cluster token to auth/kube-token
   shell: "oc whoami -t > {{ playbook_dir }}/auth/kube-token"

--- a/roles/login_ocp/tasks/main.yml
+++ b/roles/login_ocp/tasks/main.yml
@@ -10,6 +10,3 @@
   retries: 10
   delay: 6
   until: login.rc == 0
-
-- name: dump cluster token to auth/kube-token
-  shell: "oc whoami -t > {{ playbook_dir }}/auth/kube-token"

--- a/roles/ocp4_cluster_destroy/tasks/main.yml
+++ b/roles/ocp4_cluster_destroy/tasks/main.yml
@@ -1,2 +1,27 @@
+- name: Get defaults
+  include_vars:
+    file: "{{ playbook_dir }}/config/ocp4/defaults.yml"
+
+- name: Get AWS account information
+  aws_caller_facts:
+  register: caller_facts
+
+- name: Retrieve AWS account identifier (ARN) for use in resource tags
+  set_fact:
+    aws_account_arn: "{{ caller_facts.arn }}"
+    arn_and_region: "{{ caller_facts.arn }}-{{ aws_region }}"
+
+# Set this separately to explicitly mention we are setting md5 hash to include uniqueness across regions
+- set_fact:
+    aws_resource_name: "velero-{{ arn_and_region | hash('md5') }}"
+
+- name: Delete S3 bucket for backup storage of OpenShift resource definitions
+  s3_bucket:
+    state: absent
+    name: "{{ aws_resource_name }}"
+    region: "{{ aws_region }}"
+    tags:
+      owner: "{{ aws_account_arn }}"
+
 - name: destroy cluster
   shell: "{{ playbook_dir }}/openshift-install destroy cluster"


### PR DESCRIPTION
- Cluster will try to remove itself it it failed during the deployment phase.
- So as velero s3 bucket, will be removed on failure, or at the end of pipline run.
- Time waiting for cluster to log in is extended to 1 min.
- Removed token dump.