### PR TITLE
Skip ocp4 destroy when cluster not installed

### DIFF
--- a/roles/ocp4_cluster_destroy/tasks/check.yml
+++ b/roles/ocp4_cluster_destroy/tasks/check.yml
@@ -1,0 +1,4 @@
+- name: check for OCP installation
+  stat:
+    path: "{{ playbook_dir }}/.openshift_install_state.json"
+  register: ocp_install

--- a/roles/ocp4_cluster_destroy/tasks/destroy.yml
+++ b/roles/ocp4_cluster_destroy/tasks/destroy.yml
@@ -1,0 +1,27 @@
+- name: Get defaults
+  include_vars:
+    file: "{{ playbook_dir }}/config/ocp4/defaults.yml"
+
+- name: Get AWS account information
+  aws_caller_facts:
+  register: caller_facts
+
+- name: Retrieve AWS account identifier (ARN) for use in resource tags
+  set_fact:
+    aws_account_arn: "{{ caller_facts.arn }}"
+    arn_and_region: "{{ caller_facts.arn }}-{{ aws_region }}"
+
+# Set this separately to explicitly mention we are setting md5 hash to include uniqueness across regions
+- set_fact:
+    aws_resource_name: "velero-{{ arn_and_region | hash('md5') }}"
+
+- name: Delete S3 bucket for backup storage of OpenShift resource definitions
+  s3_bucket:
+    state: absent
+    name: "{{ aws_resource_name }}"
+    region: "{{ aws_region }}"
+    tags:
+      owner: "{{ aws_account_arn }}"
+
+- name: destroy cluster
+  shell: "{{ playbook_dir }}/openshift-install destroy cluster"

--- a/roles/ocp4_cluster_destroy/tasks/main.yml
+++ b/roles/ocp4_cluster_destroy/tasks/main.yml
@@ -1,27 +1,4 @@
-- name: Get defaults
-  include_vars:
-    file: "{{ playbook_dir }}/config/ocp4/defaults.yml"
+- import_tasks: check.yml
 
-- name: Get AWS account information
-  aws_caller_facts:
-  register: caller_facts
-
-- name: Retrieve AWS account identifier (ARN) for use in resource tags
-  set_fact:
-    aws_account_arn: "{{ caller_facts.arn }}"
-    arn_and_region: "{{ caller_facts.arn }}-{{ aws_region }}"
-
-# Set this separately to explicitly mention we are setting md5 hash to include uniqueness across regions
-- set_fact:
-    aws_resource_name: "velero-{{ arn_and_region | hash('md5') }}"
-
-- name: Delete S3 bucket for backup storage of OpenShift resource definitions
-  s3_bucket:
-    state: absent
-    name: "{{ aws_resource_name }}"
-    region: "{{ aws_region }}"
-    tags:
-      owner: "{{ aws_account_arn }}"
-
-- name: destroy cluster
-  shell: "{{ playbook_dir }}/openshift-install destroy cluster"
+- import_tasks: destroy.yml
+  when: ocp_install.stat.exists


### PR DESCRIPTION
This should help prevent failed attempts to destroy clusters that are not present. 