### PR TITLE
Allow throttling of OCP3 concurrent builds

### DIFF
--- a/pipeline/ocp310-base
+++ b/pipeline/ocp310-base
@@ -11,6 +11,7 @@ string(defaultValue: 'ci.pem', description: 'EC2 SSH private key filename to acc
 string(defaultValue: 'us-east-1', description: 'EC2 region to deploy instances', name: 'EC2_REGION', trim: false),
 string(defaultValue: 'm4.large', description: 'EC2 instance type to deploy', name: 'EC2_INSTANCE_TYPE', trim: false),
 booleanParam(defaultValue: true, description: 'EC2 terminate instances after build', name: 'EC2_TERMINATE_INSTANCES')]),
+[$class: 'ThrottleJobProperty', categories: ['OCP3'], limitOneJobWithMatchingParams: true, maxConcurrentPerNode: 0, maxConcurrentTotal: 0, paramsToUseForLimit: '', throttleEnabled: true, throttleOption: 'category'],
 pipelineTriggers([cron('H(0-5) 0 * * *')])])
 
 // true/false build parameter that defines if we terminate instances once build is done

--- a/pipeline/ocp310-base
+++ b/pipeline/ocp310-base
@@ -12,7 +12,7 @@ string(defaultValue: 'us-east-1', description: 'EC2 region to deploy instances',
 string(defaultValue: 'm4.large', description: 'EC2 instance type to deploy', name: 'EC2_INSTANCE_TYPE', trim: false),
 booleanParam(defaultValue: true, description: 'EC2 terminate instances after build', name: 'EC2_TERMINATE_INSTANCES')]),
 [$class: 'ThrottleJobProperty', categories: ['OCP3'], limitOneJobWithMatchingParams: true, maxConcurrentPerNode: 0, maxConcurrentTotal: 0, paramsToUseForLimit: '', throttleEnabled: true, throttleOption: 'category'],
-pipelineTriggers([cron('H(0-5) 0 * * *')])])
+pipelineTriggers([cron('@midnight')])])
 
 // true/false build parameter that defines if we terminate instances once build is done
 def EC2_TERMINATE_INSTANCES = params.EC2_TERMINATE_INSTANCES

--- a/pipeline/ocp311-base
+++ b/pipeline/ocp311-base
@@ -12,7 +12,7 @@ string(defaultValue: 'us-east-1', description: 'EC2 region to deploy instances',
 string(defaultValue: 'm4.large', description: 'EC2 instance type to deploy', name: 'EC2_INSTANCE_TYPE', trim: false),
 booleanParam(defaultValue: true, description: 'EC2 terminate instances after build', name: 'EC2_TERMINATE_INSTANCES')]),
 [$class: 'ThrottleJobProperty', categories: ['OCP3'], limitOneJobWithMatchingParams: true, maxConcurrentPerNode: 0, maxConcurrentTotal: 0, paramsToUseForLimit: '', throttleEnabled: true, throttleOption: 'category'],
-pipelineTriggers([cron('H(30-35) 0 * * *')])])
+pipelineTriggers([cron('@midnight')])])
 
 // true/false build parameter that defines if we terminate instances once build is done
 def EC2_TERMINATE_INSTANCES = params.EC2_TERMINATE_INSTANCES

--- a/pipeline/ocp311-base
+++ b/pipeline/ocp311-base
@@ -11,6 +11,7 @@ string(defaultValue: 'ci.pem', description: 'EC2 SSH private key filename to acc
 string(defaultValue: 'us-east-1', description: 'EC2 region to deploy instances', name: 'EC2_REGION', trim: false),
 string(defaultValue: 'm4.large', description: 'EC2 instance type to deploy', name: 'EC2_INSTANCE_TYPE', trim: false),
 booleanParam(defaultValue: true, description: 'EC2 terminate instances after build', name: 'EC2_TERMINATE_INSTANCES')]),
+[$class: 'ThrottleJobProperty', categories: ['OCP3'], limitOneJobWithMatchingParams: true, maxConcurrentPerNode: 0, maxConcurrentTotal: 0, paramsToUseForLimit: '', throttleEnabled: true, throttleOption: 'category'],
 pipelineTriggers([cron('H(30-35) 0 * * *')])])
 
 // true/false build parameter that defines if we terminate instances once build is done

--- a/pipeline/ocp37-base
+++ b/pipeline/ocp37-base
@@ -11,6 +11,7 @@ string(defaultValue: 'ci.pem', description: 'EC2 SSH private key filename to acc
 string(defaultValue: 'us-east-1', description: 'EC2 region to deploy instances', name: 'EC2_REGION', trim: false),
 string(defaultValue: 'm4.large', description: 'EC2 instance type to deploy', name: 'EC2_INSTANCE_TYPE', trim: false),
 booleanParam(defaultValue: true, description: 'EC2 terminate instances after build', name: 'EC2_TERMINATE_INSTANCES')]),
+[$class: 'ThrottleJobProperty', categories: ['OCP3'], limitOneJobWithMatchingParams: true, maxConcurrentPerNode: 0, maxConcurrentTotal: 0, paramsToUseForLimit: '', throttleEnabled: true, throttleOption: 'category'],
 pipelineTriggers([cron('H(0-5) 23 * * *')])])
 
 // true/false build parameter that defines if we terminate instances once build is done

--- a/pipeline/ocp37-base
+++ b/pipeline/ocp37-base
@@ -12,7 +12,7 @@ string(defaultValue: 'us-east-1', description: 'EC2 region to deploy instances',
 string(defaultValue: 'm4.large', description: 'EC2 instance type to deploy', name: 'EC2_INSTANCE_TYPE', trim: false),
 booleanParam(defaultValue: true, description: 'EC2 terminate instances after build', name: 'EC2_TERMINATE_INSTANCES')]),
 [$class: 'ThrottleJobProperty', categories: ['OCP3'], limitOneJobWithMatchingParams: true, maxConcurrentPerNode: 0, maxConcurrentTotal: 0, paramsToUseForLimit: '', throttleEnabled: true, throttleOption: 'category'],
-pipelineTriggers([cron('H(0-5) 23 * * *')])])
+pipelineTriggers([cron('@midnight')])])
 
 // true/false build parameter that defines if we terminate instances once build is done
 def EC2_TERMINATE_INSTANCES = params.EC2_TERMINATE_INSTANCES

--- a/pipeline/ocp39-base
+++ b/pipeline/ocp39-base
@@ -12,7 +12,7 @@ string(defaultValue: 'us-east-1', description: 'EC2 region to deploy instances',
 string(defaultValue: 'm4.large', description: 'EC2 instance type to deploy', name: 'EC2_INSTANCE_TYPE', trim: false),
 booleanParam(defaultValue: true, description: 'EC2 terminate instances after build', name: 'EC2_TERMINATE_INSTANCES')]),
 [$class: 'ThrottleJobProperty', categories: ['OCP3'], limitOneJobWithMatchingParams: true, maxConcurrentPerNode: 0, maxConcurrentTotal: 0, paramsToUseForLimit: '', throttleEnabled: true, throttleOption: 'category'],
-pipelineTriggers([cron('H(30-35) 23 * * *')])])
+pipelineTriggers([cron('@midnight')])])
 
 // true/false build parameter that defines if we terminate instances once build is done
 def EC2_TERMINATE_INSTANCES = params.EC2_TERMINATE_INSTANCES

--- a/pipeline/ocp39-base
+++ b/pipeline/ocp39-base
@@ -11,6 +11,7 @@ string(defaultValue: 'ci.pem', description: 'EC2 SSH private key filename to acc
 string(defaultValue: 'us-east-1', description: 'EC2 region to deploy instances', name: 'EC2_REGION', trim: false),
 string(defaultValue: 'm4.large', description: 'EC2 instance type to deploy', name: 'EC2_INSTANCE_TYPE', trim: false),
 booleanParam(defaultValue: true, description: 'EC2 terminate instances after build', name: 'EC2_TERMINATE_INSTANCES')]),
+[$class: 'ThrottleJobProperty', categories: ['OCP3'], limitOneJobWithMatchingParams: true, maxConcurrentPerNode: 0, maxConcurrentTotal: 0, paramsToUseForLimit: '', throttleEnabled: true, throttleOption: 'category'],
 pipelineTriggers([cron('H(30-35) 23 * * *')])])
 
 // true/false build parameter that defines if we terminate instances once build is done


### PR DESCRIPTION
All OCP3 nightly builds can now be throttled, this eliminates issues when running concurrent builds that might step on each other. An OCP3 category was created on the Jenkins side and it is referenced by each of the pipeline scripts for OCP3 builds.
