### PR TITLE
Allow NFS PVs to be provisioned on OCP deployments

### DIFF
--- a/pipeline/mig-e2e
+++ b/pipeline/mig-e2e
@@ -58,7 +58,7 @@ node {
             }
             
             echo 'Cloning mig-ci repo'
-            checkout([$class: 'GitSCM', branches: [[name: '*/master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'mig-ci']], submoduleCfg: [], userRemoteConfigs: [[url: 'https://github.com/fusor/mig-ci.git']]])
+            checkout([$class: 'GitSCM', branches: [[name: '*/add_ocp_nfs_pvs']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'mig-ci']], submoduleCfg: [], userRemoteConfigs: [[url: 'https://github.com/fbladilo/mig-ci.git']]])
 
             // Set enviroment variables
             EC2_REGION = "${EC2_REGION}"

--- a/pipeline/mig-e2e
+++ b/pipeline/mig-e2e
@@ -58,7 +58,7 @@ node {
             }
             
             echo 'Cloning mig-ci repo'
-            checkout([$class: 'GitSCM', branches: [[name: '*/add_ocp_nfs_pvs']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'mig-ci']], submoduleCfg: [], userRemoteConfigs: [[url: 'https://github.com/fbladilo/mig-ci.git']]])
+            checkout([$class: 'GitSCM', branches: [[name: '*/master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'mig-ci']], submoduleCfg: [], userRemoteConfigs: [[url: 'https://github.com/fusor/mig-ci.git']]])
 
             // Set enviroment variables
             EC2_REGION = "${EC2_REGION}"

--- a/pipeline/mig-e2e
+++ b/pipeline/mig-e2e
@@ -121,7 +121,20 @@ node {
                 }
             }
         }
-        
+
+	stage('Configure NFS storage on OCP3') {
+		dir('mig-ci') {
+                        ansiColor('xterm') {
+                            ansiblePlaybook(
+                                playbook: 'setup_nfs_storage.yml',
+                                extras: "-e ec2_private_key_file=$KEYS_DIR/$EC2_PRIVATE_KEY_FILE",
+                                hostKeyChecking: false,
+                                unbuffered: true,
+                                colorized: true)
+			}
+		}
+	}
+	
         stage('Deploy Velero and configure S3 storage on OCP3') {
             withCredentials([
                 string(credentialsId: "$EC2_ACCESS_KEY_ID", variable: 'AWS_ACCESS_KEY_ID'),

--- a/roles/ocp_setup_nfs/tasks/main.yml
+++ b/roles/ocp_setup_nfs/tasks/main.yml
@@ -1,0 +1,38 @@
+- name: Remove hostPath pv's
+  shell: "for i in $(oc get pv --no-headers | awk '{ print $1 }'); do oc delete pv $i; done"
+
+- name: install nfs-utils
+  package:
+    name: nfs-utils
+    state: latest
+  become: true
+
+- name: create exports file
+  copy:
+    content: |
+             /var/lib/nfs/exports *(rw,no_root_squash)
+    dest: /etc/exports
+  become: true
+
+- name: Create pv dirs
+  file:
+    path: "/var/lib/nfs/exports/pv{{ item }}"
+    state: directory
+    mode: 0777
+  with_sequence: start=1 end=9 
+  become: true
+
+- name: Create pv.yml
+  template:
+    src: pv.yml.j2
+    dest: /tmp/pv.yml
+
+- name: Start and enable nfs-server
+  systemd:
+    name: nfs-server
+    state: started
+    enabled: true
+  become: true
+
+- name: Create nfs pv's
+  shell: "oc create -f /tmp/pv.yml"

--- a/roles/ocp_setup_nfs/templates/pv.yml.j2
+++ b/roles/ocp_setup_nfs/templates/pv.yml.j2
@@ -1,0 +1,155 @@
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv1
+spec:
+  capacity:
+    storage: 100Gi
+  accessModes:
+    - ReadWriteMany
+    - ReadWriteOnce
+    - ReadOnlyMany
+  persistentVolumeReclaimPolicy: Retain
+  nfs:
+    server: {{ ansible_default_ipv4.address }}
+    path: "/var/lib/nfs/exports/pv1"
+
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv2
+spec:
+  capacity:
+    storage: 100Gi
+  accessModes:
+    - ReadWriteMany
+    - ReadWriteOnce
+    - ReadOnlyMany
+  persistentVolumeReclaimPolicy: Retain
+  nfs:
+    server: {{ ansible_default_ipv4.address }}
+    path: "/var/lib/nfs/exports/pv2"
+
+
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv3
+spec:
+  capacity:
+    storage: 100Gi
+  accessModes:
+    - ReadWriteMany
+    - ReadWriteOnce
+    - ReadOnlyMany
+  persistentVolumeReclaimPolicy: Retain
+  nfs:
+    server: {{ ansible_default_ipv4.address }}
+    path: "/var/lib/nfs/exports/pv3"
+
+
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv4
+spec:
+  capacity:
+    storage: 100Gi
+  accessModes:
+    - ReadWriteMany
+    - ReadWriteOnce
+    - ReadOnlyMany
+  persistentVolumeReclaimPolicy: Retain
+  nfs:
+    server: {{ ansible_default_ipv4.address }}
+    path: "/var/lib/nfs/exports/pv4"
+
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv5
+spec:
+  capacity:
+    storage: 100Gi
+  accessModes:
+    - ReadWriteMany
+    - ReadWriteOnce
+    - ReadOnlyMany
+  persistentVolumeReclaimPolicy: Retain
+  nfs:
+    server: {{ ansible_default_ipv4.address }}
+    path: "/var/lib/nfs/exports/pv5"
+
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv6
+spec:
+  capacity:
+    storage: 100Gi
+  accessModes:
+    - ReadWriteMany
+    - ReadWriteOnce
+    - ReadOnlyMany
+  persistentVolumeReclaimPolicy: Retain
+  nfs:
+    server: {{ ansible_default_ipv4.address }}
+    path: "/var/lib/nfs/exports/pv6"
+
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv7
+spec:
+  capacity:
+    storage: 100Gi
+  accessModes:
+    - ReadWriteMany
+    - ReadWriteOnce
+    - ReadOnlyMany
+  persistentVolumeReclaimPolicy: Retain
+  nfs:
+    server: {{ ansible_default_ipv4.address }}
+    path: "/var/lib/nfs/exports/pv7"
+
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv8
+spec:
+  capacity:
+    storage: 100Gi
+  accessModes:
+    - ReadWriteMany
+    - ReadWriteOnce
+    - ReadOnlyMany
+  persistentVolumeReclaimPolicy: Retain
+  nfs:
+    server: {{ ansible_default_ipv4.address }}
+    path: "/var/lib/nfs/exports/pv8"
+
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv9
+spec:
+  capacity:
+    storage: 100Gi
+  accessModes:
+    - ReadWriteMany
+    - ReadWriteOnce
+    - ReadOnlyMany
+  persistentVolumeReclaimPolicy: Retain
+  nfs:
+    server: {{ ansible_default_ipv4.address }}
+    path: "/var/lib/nfs/exports/pv9"
+

--- a/setup_nfs_storage.yml
+++ b/setup_nfs_storage.yml
@@ -1,0 +1,30 @@
+---
+- name: Add OCP EC2 instance host to in memory inventory
+  hosts: localhost
+  tasks:
+    - shell: "tail -1 {{ ansible_env.HOME }}/.ssh/known_hosts | cut -d ' ' -f1"
+      register: ocp_ip
+
+    - set_fact:
+        ec2_ip: "{{ ocp_ip.stdout }}"
+
+    - add_host:
+        name: "{{ ec2_ip }}"
+        group: ocp_nfs_servers
+        ansible_user: "{{ ec2_user }}"
+        ansible_ssh_private_key_file: "{{ ec2_private_key_file }}"
+  vars:
+    ec2_user: "ec2-user"
+    ec2_private_key_file: "../keys/ci.pem"
+  tags:
+    - always
+
+- name: Setup OCP NFS storage
+  hosts: ocp_nfs_servers
+  tasks:
+  vars:
+    ansible_ssh_common_args: -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
+  roles:
+    - { role: ocp_setup_nfs }
+  environment:
+    PATH: "{{ ansible_env.PATH }}:~/bin"


### PR DESCRIPTION
@Danil-Grigorev Sample mig-e2e OCP3 deployment with MYSQL bound to NFS PVs , see below :
```
[ec2-user@ip-10-0-1-168 ~]$ oc project mysql-persistent
Now using project "mysql-persistent" on server "https://127.0.0.1:8443".
[ec2-user@ip-10-0-1-168 ~]$ oc get pvc
NAME      STATUS    VOLUME    CAPACITY   ACCESS MODES   STORAGECLASS   AGE
mysql     Bound     pv8       100Gi      RWO,ROX,RWX                   1m
[ec2-user@ip-10-0-1-168 ~]$ oc describe pv pv8
Name:            pv8
Labels:          <none>
Annotations:     pv.kubernetes.io/bound-by-controller=yes
Finalizers:      [kubernetes.io/pv-protection]
StorageClass:    
Status:          Bound
Claim:           mysql-persistent/mysql
Reclaim Policy:  Retain
Access Modes:    RWO,ROX,RWX
Capacity:        100Gi
Node Affinity:   <none>
Message:         
Source:
    Type:      NFS (an NFS mount that lasts the lifetime of a pod)
    Server:    10.0.1.168
    Path:      /var/lib/nfs/exports/pv8
    ReadOnly:  false
Events:        <none>
[ec2-user@ip-10-0-1-168 ~]$ 
```
