### PR TITLE
Fix cluster_version issues on velero setup

### DIFF
--- a/roles/mig_tools_setup/tasks/main.yml
+++ b/roles/mig_tools_setup/tasks/main.yml
@@ -21,7 +21,7 @@
 
 - name: launching velero on OCP-3
   block:
-    - name: Logging to OCP4 and saving credentials
+    - name: Logging to OCP3 and saving credentials
       include_role:
         name: login_ocp
       vars:

--- a/setup_velero.yml
+++ b/setup_velero.yml
@@ -1,8 +1,6 @@
 - hosts: localhost
-  vars:
-    cluster_version: '4'
   roles:
   - mig_tools_prereqs
   - role: mig_tools_setup
     vars:
-      cluster_version: "{{ cluster_version }}"
+      cluster_version: "{{ lookup('env', 'CLUSTER_VERSION') or '4'}}"


### PR DESCRIPTION
- Remove conflictive cluster_version defines on playbook
- We check for environment CLUSTER_VERSION or assume version 4 if not found
- OCP3 deployments MUST specify either CLUSTER_VERSION or pass extra variable to playbook via "-e cluster_version=x"