### PR TITLE
Update backupstoragelocation to sync with upstream velero

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.retry
 *.swp
 velero/*
+auth/*
 config/velero_aws_creds*
 \.openshift_install*
 metadata.json

--- a/roles/mig_tools_setup/tasks/launch_velero.yml
+++ b/roles/mig_tools_setup/tasks/launch_velero.yml
@@ -43,7 +43,14 @@
     state: "{{ state }}"
     definition: "{{ lookup('file', '{{ playbook_dir }}/velero/config/minio/30-restic-daemonset.yaml')}}"
 
-- name: Check velero deployment is finished
+- name: Integrate velero plugin
+  shell: "{{ playbook_dir }}/velero/velero plugin add quay.io/ocpmigrate/velero-plugin"
+
+# Pause and allow velero plugin to settle to avoid false positive on deployment check
+- pause:
+    seconds: 15
+
+- name: Check status of velero deployment
   k8s_facts:
     kind: Deployment
     api_version: extensions/v1beta1
@@ -53,12 +60,8 @@
   register: deploy
   until:  deploy.get("resources", [])
           and deploy.resources[0].get("spec", {}).get("replicas", -1) == deploy.resources[0].get("status", {}).get("availableReplicas", 0)
-  retries: 30
-  delay: 10
-
-# Allow velero deployment to settle before adding plugin init-container
-- name: Integrate velero plugin
-  shell: "{{ playbook_dir }}/velero/velero plugin add quay.io/ocpmigrate/velero-plugin"
+  retries: 60
+  delay: 5
 
 - name: Fix restic pod dir mount for oc cluster up install
   shell: "oc set volume -n velero ds/restic --add --name=host-pods --path /tmp/openshift.local.clusterup/openshift.local.volumes/pods --overwrite"

--- a/roles/mig_tools_setup/tasks/launch_velero.yml
+++ b/roles/mig_tools_setup/tasks/launch_velero.yml
@@ -43,9 +43,6 @@
     state: "{{ state }}"
     definition: "{{ lookup('file', '{{ playbook_dir }}/velero/config/minio/30-restic-daemonset.yaml')}}"
 
-- name: Integrate velero plugin
-  shell: "{{ playbook_dir }}/velero/velero plugin add quay.io/ocpmigrate/velero-plugin"
-
 - name: Check velero deployment is finished
   k8s_facts:
     kind: Deployment
@@ -56,8 +53,12 @@
   register: deploy
   until:  deploy.get("resources", [])
           and deploy.resources[0].get("spec", {}).get("replicas", -1) == deploy.resources[0].get("status", {}).get("availableReplicas", 0)
-  retries: 60
-  delay: 5
+  retries: 30
+  delay: 10
+
+# Allow velero deployment to settle before adding plugin init-container
+- name: Integrate velero plugin
+  shell: "{{ playbook_dir }}/velero/velero plugin add quay.io/ocpmigrate/velero-plugin"
 
 - name: Fix restic pod dir mount for oc cluster up install
   shell: "oc set volume -n velero ds/restic --add --name=host-pods --path /tmp/openshift.local.clusterup/openshift.local.volumes/pods --overwrite"

--- a/roles/mig_tools_setup/templates/05-ark-aws-backupstoragelocation.yaml.j2
+++ b/roles/mig_tools_setup/templates/05-ark-aws-backupstoragelocation.yaml.j2
@@ -19,7 +19,7 @@ metadata:
   name: default
   namespace: velero
 spec:
-  provider: aws
+  provider: velero.io/aws
   objectStorage:
     bucket: {{ velero_aws_bucket_name }}
   config:


### PR DESCRIPTION
@Danil-Grigorev @evgeny-chufarov This fixes velero crashes on OCP4 and OCP3 when attempting to access backupstoragelocation default. Please ensure you are using latest images to test.
Reference : https://github.com/fusor/ocp-velero-ansible/pull/17
