### PR TITLE
Do not modify restic pod dir on OCP4 clusters

### DIFF
--- a/roles/mig_tools_setup/tasks/launch_velero.yml
+++ b/roles/mig_tools_setup/tasks/launch_velero.yml
@@ -76,7 +76,3 @@
 - name: Fix restic pod dir mount for oc cluster up install
   shell: "{{ oc_binary_location }}/oc set volume -n velero ds/restic --add --name=host-pods --path /tmp/openshift.local.clusterup/openshift.local.volumes/pods --overwrite"
   when: cluster_version == '3'
-
-- name: Fix restic pod dir mount for openshift-ansible install
-  shell: "{{ oc_binary_location }}/oc set volume -n velero ds/restic --add --name=host-pods --path /var/lib/origin/openshift.local.volumes/pods --overwrite"
-  when: cluster_version == '4'


### PR DESCRIPTION
There is no need to modify the default pod dir for restic on OCP4 deployments, /var/lib/kubelet/pods is  the correct location. See sample restic pod below:
```
oc version
oc v3.11.0+0cbc58b
kubernetes v1.11.0+d4cacc0
features: Basic-Auth GSSAPI Kerberos SPNEGO

Server https://api.franco-dev8.mg.dog8code.com:6443
kubernetes v1.12.4+0f8e04e

oc describe pods | grep -A3 host-pods:
  host-pods:
    Type:          HostPath (bare host directory volume)
    Path:          /var/lib/kubelet/pods
    HostPathType:  

oc rsh restic-b86zm ls -la /host_pods
total 4
drwxr-x---. 33 root root 4096 Apr 23 00:17 .
drwxr-xr-x.  1 root root   90 Apr 22 22:22 ..
drwxr-x---.  5 root root   71 Apr 22 22:29 04790a1f-654e-11e9-83ac-0a511639736e
drwxr-x---.  5 root root   71 Apr 22 03:53 1a4b8b25-64b2-11e9-b3d3-0a511639736e
drwxr-x---.  5 root root   71 Apr 22 03:52 1ab0217c-64b2-11e9-b3d3-0a511639736e
drwxr-x---.  5 root root   71 Apr 22 03:52 1c380cd9-64b2-11e9-b3d3-0a511639736e
drwxr-x---.  5 root root   71 Apr 22 03:53 1e24d2e1-64b2-11e9-b3d3-0a511639736e
drwxr-x---.  5 root root   71 Apr 22 03:53 235757cf-64b2-11e9-b3d3-0a511639736e
drwxr-x---.  5 root root   71 Apr 22 03:53 2361002d-64b2-11e9-b3d3-0a511639736e
drwxr-x---.  5 root root   71 Apr 22 03:53 24d6921f-64b2-11e9-b3d3-0a511639736e
drwxr-x---.  5 root root   71 Apr 22 22:22 2675c152-654d-11e9-83ac-0a511639736e
drwxr-x---.  5 root root   71 Apr 22 03:53 292eeade-64b2-11e9-b3d3-0a511639736e
```