### PR TITLE
Use mig-controller velero deployment instead of existing roles

### DIFF
--- a/roles/mig_controller_deploy/defaults/main.yml
+++ b/roles/mig_controller_deploy/defaults/main.yml
@@ -1,1 +1,2 @@
 ---
+with_controller: true

--- a/roles/mig_controller_deploy/tasks/main.yml
+++ b/roles/mig_controller_deploy/tasks/main.yml
@@ -9,6 +9,7 @@
 
 - name: Deploy mig controller
   import_tasks: deploy.yml
+  when: with_controller
 
 - name: Process mig controller deployment summary
   import_tasks: summary.yml

--- a/roles/mig_controller_deploy/templates/mig_controller.yml.j2
+++ b/roles/mig_controller_deploy/templates/mig_controller.yml.j2
@@ -1,6 +1,6 @@
 mig_controller_remote_cluster_url: {{ dest_cluster_url }}
-mig_controller_aws_access_key: {{ velero_aws_access_key }}
-mig_controller_aws_secret_key: {{ velero_aws_secret_key }}
+mig_controller_aws_access_key: {{ velero_aws_access_key | b64encode }}
+mig_controller_aws_secret_key: {{ velero_aws_secret_key | b64encode }}
 mig_controller_aws_bucket_name: {{ velero_aws_bucket_name }}
 mig_controller_aws_bucket_region: {{ ec2_region }}
 mig_controller_sa_token: {{ sa_token }}

--- a/roles/mig_controller_prereqs/tasks/apply_ocp3_fixes.yml
+++ b/roles/mig_controller_prereqs/tasks/apply_ocp3_fixes.yml
@@ -1,0 +1,34 @@
+# Apply misc cluster fixes for velero/restic integration
+
+- name: Apply OCP3 fixes
+  block:
+    - name: Get AWS account information
+      local_action:
+        module: aws_caller_facts
+      register: caller_facts
+  
+    - name: Get instance info
+      local_action:
+        module: ec2_instance_facts
+        region: "{{ ec2_region }}"
+        filters:
+          "tag:Name": "{{ ansible_user }}-origin3-dev"
+          "tag:creator_arn": "{{ caller_facts.arn }}"
+      register: ec2_instance
+
+    - name: Extract public ip
+      set_fact:
+        instance_ip: "{{ (ec2_instance.instances | selectattr('state.name', 'match', '^running$') | list )[0]['public_ip_address'] }}"
+
+    - name: Add OCP EC2 instance host to in memory inventory
+      add_host:
+        name: "{{ instance_ip }}"
+        ansible_user: "{{ ec2_ssh_user }}"
+        ansible_ssh_private_key_file: "{{ ec2_private_key_file }}"
+
+    - name: Set origin pod dir selinux context to match prod installs (restic fix)
+      shell: "chcon -R -t container_file_t /tmp/openshift.local.clusterup/openshift.local.volumes/pods/"
+      become: true
+      ignore_errors: yes
+      delegate_to: "{{ instance_ip }}"
+  when: cluster_version == '3'

--- a/roles/mig_controller_prereqs/tasks/create_aws_backup_storage.yml
+++ b/roles/mig_controller_prereqs/tasks/create_aws_backup_storage.yml
@@ -1,0 +1,76 @@
+- name: Check that velero_aws_credentials were created
+  stat:
+    path: "{{ playbook_dir }}/config/velero_aws_creds.yml"
+  register: creds
+
+- name: Create new S3 bucket if was not created
+  block:
+
+    - name: Get AWS account information
+      aws_caller_facts:
+      register: caller_facts
+
+    - name: Retrieve AWS account identifier (ARN) for use in resource tags
+      set_fact:
+        aws_account_arn: "{{ caller_facts.arn }}"
+        arn_and_region: "{{ caller_facts.arn }}-{{ ec2_region }}"
+
+    # Set this separately to explicitly mention we are setting md5 hash to include uniqueness across regions
+    - set_fact:
+        aws_resource_name: "velero-{{ arn_and_region | hash('md5') }}"
+
+    - name: Create S3 bucket for backup storage of OpenShift resource definitions
+      s3_bucket:
+        state: present
+        name: "{{ aws_resource_name }}"
+        region: "{{ ec2_region }}"
+        tags:
+          owner: "{{ aws_account_arn }}"
+
+    - name: Create IAM user for Velero to assume role of
+      iam_user:
+        state: present
+        name: "{{ aws_resource_name }}"
+
+    - name: Create IAM policy entitling Velero user access to S3 bucket and EBS volume storage
+      iam_policy:
+        state: present
+        iam_type: user
+        iam_name: "{{ aws_resource_name }}"
+        policy_name: "{{ aws_resource_name }}"
+        policy_json: "{{ lookup( 'template', 'velero_policy.json.j2') }}"
+
+    - name: Get AWS access key info for Velero IAM user
+      iam:
+        iam_type: user
+        name: "{{ aws_resource_name }}"
+        state: present
+      register: iam_result
+
+    - name: Remove existing AWS access keys for Velero IAM user
+      iam:
+        iam_type: user
+        name: "{{ aws_resource_name }}"
+        state: update
+        access_key_ids: "{{ item.access_key_id }}"
+        access_key_state: remove
+      loop: "{{ iam_result.user_meta.access_keys }}"
+
+    - name: Create new AWS access keys for Velero IAM user
+      iam:
+        iam_type: user
+        name: "{{ aws_resource_name }}"
+        state: update
+        access_key_state: create
+      register: iam_result
+
+    - name: Store new AWS access keys
+      set_fact:
+        velero_aws_access_key: "{{ iam_result.created_keys[0].access_key_id }}"
+        velero_aws_secret_key: "{{ iam_result.created_keys[0].secret_access_key }}"
+
+    - name: Write Velero AWS access keys to config/velero_aws_creds.yml
+      template:
+        src: velero_aws_creds.yml.j2
+        dest: "{{ playbook_dir }}/config/velero_aws_creds.yml"
+  when: not creds.stat.exists

--- a/roles/mig_controller_prereqs/tasks/deploy_velero.yml
+++ b/roles/mig_controller_prereqs/tasks/deploy_velero.yml
@@ -1,0 +1,37 @@
+- name: Deploy velero
+  command: "{{ mig_controller_location }}/hack/deploy/deploy_velero.sh"
+  register: deploy
+
+- debug:
+    var: deploy.stdout_lines
+
+- name: Check status of velero deployment
+  k8s_facts:
+    kind: Deployment
+    api_version: extensions/v1beta1
+    namespace: velero
+    name: velero
+    label_selectors: "component=velero"
+  register: deploy
+  until:  deploy.get("resources", [])
+          and deploy.resources[0].get("spec", {}).get("replicas", -1) == deploy.resources[0].get("status", {}).get("availableReplicas", 0)
+  retries: 60
+  delay: 5
+
+# Fix me: reconfigure when we move to OA based installations
+- name: Fix restic pod dir mount for oc cluster up install
+  shell: "{{ oc_binary_location }}/oc set volume -n velero ds/restic --add --name=host-pods --path /tmp/openshift.local.clusterup/openshift.local.volumes/pods --overwrite"
+  when: cluster_version == '3'
+
+- name: Check status of restic deployment
+  k8s_facts:
+    kind: DaemonSet
+    api_version: extensions/v1beta1
+    namespace: velero
+    name: restic
+    label_selectors: "name=restic"
+  register: dset
+  until: dset.get("resources", [])
+         and dset.resources[0].get("status", {}).get("desiredNumberScheduled", -1) == dset.resources[0].get("status", {}).get("numberReady", 0)
+  retries: 60
+  delay: 5

--- a/roles/mig_controller_prereqs/tasks/main.yml
+++ b/roles/mig_controller_prereqs/tasks/main.yml
@@ -1,38 +1,13 @@
 ---
-- name: Logging to OCP4 and saving credentials
-  include_role:
-    name: login_ocp
-  vars:
-    source_kubeconfig: "{{ playbook_dir }}/auth/kubeconfig"
-    target_kubeconfig: "{{ ocp4_kubeconfig }}"
 
-- name: Start remote cluster tasks
-  block:
+- name: Create AWS backup storage
+  import_tasks: create_aws_backup_storage.yml
 
-    - name: Create mig controller SA and role binding on remote cluster
-      k8s:
-        state: present
-        definition: "{{ lookup('template', 'mig_controller_sa.yml.j2') }}"
+- name: Apply velero OCP3 fixes
+  import_tasks: apply_ocp3_fixes.yml
 
-    - name: Extract SA token
-      shell: "{{ oc_binary_location }}/oc sa get-token -n {{ mig_controller_namespace }} {{ mig_controller_sa_name }} | base64 -w 0"
-      register: oc_sa_output
+- name: Deploy velero
+  import_tasks: deploy_velero.yml
 
-    - set_fact:
-        sa_token: "{{ oc_sa_output.stdout }}"
-
-     # Fix me: need to find a better way to obtain the master API url from k8s_facts
-     # Current context always returns only one entry 
-
-    - name: Extract cluster URL from current context
-      shell: "{{ oc_binary_location }}/oc  project | sed 's/.*\\(https:\\)/\\1/' | cut -d \\\" -f1"
-      register: oc_config_output
-     
-    - set_fact:
-       dest_cluster_url: "{{ oc_config_output.stdout }}"
-
-    - debug:
-        msg: "Destination cluster URL set to: {{ dest_cluster_url }}"
-
-  environment:
-    KUBECONFIG: "{{ ocp4_kubeconfig }}"
+- name: Prepare remote cluster
+  import_tasks: prepare_remote_cluster.yml

--- a/roles/mig_controller_prereqs/tasks/prepare_remote_cluster.yml
+++ b/roles/mig_controller_prereqs/tasks/prepare_remote_cluster.yml
@@ -1,0 +1,33 @@
+---
+- name: Logging to OCP4 and saving credentials
+  include_role:
+    name: login_ocp
+  vars:
+    source_kubeconfig: "{{ playbook_dir }}/auth/kubeconfig"
+    target_kubeconfig: "{{ ocp4_kubeconfig }}"
+
+- name: Start remote cluster tasks
+  block:
+
+    - name: Extract SA token
+      shell: "{{ oc_binary_location }}/oc sa get-token -n {{ mig_controller_namespace }} {{ mig_controller_sa_name }} | base64 -w 0"
+      register: oc_sa_output
+
+    - set_fact:
+        sa_token: "{{ oc_sa_output.stdout }}"
+
+     # Fix me: need to find a better way to obtain the master API url from k8s_facts
+     # Current context always returns only one entry 
+
+    - name: Extract cluster URL from current context
+      shell: "{{ oc_binary_location }}/oc  project | sed 's/.*\\(https:\\)/\\1/' | cut -d \\\" -f1"
+      register: oc_config_output
+     
+    - set_fact:
+       dest_cluster_url: "{{ oc_config_output.stdout }}"
+
+    - debug:
+        msg: "Destination cluster URL set to: {{ dest_cluster_url }}"
+
+  environment:
+    KUBECONFIG: "{{ ocp4_kubeconfig }}"


### PR DESCRIPTION
This PR implements the new velero deployment procedure as a pre-requirement of the mig-controller deployment. The bulk of work is actually performed by a shell script within the mig-controller repo : 

https://github.com/fusor/mig-controller/blob/master/hack/deploy/deploy_velero.sh

In summary the following takes place when invoking a mig-controller deployment playbook : 

1. AWS S3 backup storage is configured
2. Apply velero OCP3 fixes for oc cluster up cases (can be removed once moved onto OA)
3. Deployment of velero/restic from mig-controller scripts along with validation for both
4. Prepare the remote cluster (OCP4) by extracting SA token and cluster API URL
5. Deployment of mig-controller onto hosting cluster
6. Create mig-controller deployment summary var file for later ingestion by e2e jobs

The mig_controller_deploy playbook now takes an extra variable (with_controller) to decide if we want to deploy the controller (by default yes) but can be manipulated for use cases where we only need velero deployed.
```
ansible-playbook mig_controller_deploy.yml -e "with_controller=false"
```
These roles obsolete the mig_tools_prereqs and mig_tools_setup previously used to setup velero and restic. I will send another cleanup PR to remove them, I have not yet since most pipeline scripts need an update before that.