### PR TITLE
ec2_provison make wait_for task more resilient

### DIFF
--- a/roles/ec2_provision/tasks/get_ip.yml
+++ b/roles/ec2_provision/tasks/get_ip.yml
@@ -22,8 +22,11 @@
     host: "{{ ec2_instance_ip }}"
     port: 22
     search_regex: OpenSSH
-    delay: 10
-    timeout: 900
+    delay: 20
+    timeout: 300
+  register: result
+  until: result is succeeded
+  retries: 5
 
 - debug:
     var: ec2_instance_ip


### PR DESCRIPTION
This should help reduce the number of failures when AWS network resources are not yet ready and wait_for gets to run. Increased the delay to 20 seconds, it will now wait at least 20 seconds before starting to poll. In case wait_for throws an unhandled exception (connection resets) it will retry 5 times via until loop.

Based on :  https://github.com/fusor/origin3-dev/pull/34
Original wait_for issue : https://github.com/ansible/ansible/issues/36223