### PR TITLE
Changing aws region to be handled by env.

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -6,7 +6,7 @@ workspace: "{{ lookup('env', 'WORKSPACE') or '../'}}"
 # AWS / EC2 related
 aws_access_key_id: "{{ lookup('env','AWS_ACCESS_KEY_ID') }}"
 aws_secret_access_key: "{{ lookup('env','AWS_SECRET_ACCESS_KEY') }}"
-ec2_region: "{{ lookup('env', 'EC2_REGION') or 'us-east-1' }}"
+ec2_region: "{{ lookup('env', 'EC2_REGION') or lookup('env', 'AWS_REGION') or 'us-east-1' }}"
 ec2_key: "{{ lookup('ENV', 'EC2_KEY') or 'ci' }}"
 ec2_private_key_file: "{{ workspace }}/keys/{{ ec2_key }}.pem"
 ec2_ssh_user: "ec2-user"

--- a/pipeline/ocp310-base
+++ b/pipeline/ocp310-base
@@ -46,7 +46,6 @@ node {
                 sh 'rm -f overrides.yml'
                 def overrides = ['ec2_key': "$EC2_KEY",
                     'ec2_private_key_file': "$KEYS_DIR/$EC2_PRIVATE_KEY_FILE",
-                    'ec2_region': "$EC2_REGION",
                     'ec2_instance_type': "$EC2_INSTANCE_TYPE",
                     'ec2_repo_create': false,
                     'openshift_setup_client_version': "$OPENSHIFT_VERSION",
@@ -65,7 +64,8 @@ node {
         stage('Deploy OCP3') {
             withCredentials([
                 string(credentialsId: "$EC2_ACCESS_KEY_ID", variable: 'AWS_ACCESS_KEY_ID'),
-                string(credentialsId: "$EC2_SECRET_ACCESS_KEY", variable: 'AWS_SECRET_ACCESS_KEY')
+                string(credentialsId: "$EC2_SECRET_ACCESS_KEY", variable: 'AWS_SECRET_ACCESS_KEY'),
+                string(credentialsId: "$EC2_REGION", variable: 'AWS_REGION')
                 ]) 
             {
                 dir('origin3-dev') {
@@ -121,7 +121,8 @@ node {
                 
                 	withCredentials([
                     		string(credentialsId: "$EC2_ACCESS_KEY_ID", variable: 'AWS_ACCESS_KEY_ID'),
-				string(credentialsId: "$EC2_SECRET_ACCESS_KEY", variable: 'AWS_SECRET_ACCESS_KEY')
+                            string(credentialsId: "$EC2_SECRET_ACCESS_KEY", variable: 'AWS_SECRET_ACCESS_KEY'),
+                            string(credentialsId: "$EC2_REGION", variable: 'AWS_REGION')
                     	]) 
                 {
                     dir('origin3-dev') {

--- a/pipeline/ocp311-base
+++ b/pipeline/ocp311-base
@@ -46,7 +46,6 @@ node {
                 sh 'rm -f overrides.yml'
                 def overrides = ['ec2_key': "$EC2_KEY",
                     'ec2_private_key_file': "$KEYS_DIR/$EC2_PRIVATE_KEY_FILE",
-                    'ec2_region': "$EC2_REGION",
                     'ec2_instance_type': "$EC2_INSTANCE_TYPE",
                     'ec2_repo_create': false,
                     'openshift_setup_client_version': "$OPENSHIFT_VERSION",
@@ -65,7 +64,8 @@ node {
         stage('Deploy OCP3') {
             withCredentials([
                 string(credentialsId: "$EC2_ACCESS_KEY_ID", variable: 'AWS_ACCESS_KEY_ID'),
-                string(credentialsId: "$EC2_SECRET_ACCESS_KEY", variable: 'AWS_SECRET_ACCESS_KEY')
+                string(credentialsId: "$EC2_SECRET_ACCESS_KEY", variable: 'AWS_SECRET_ACCESS_KEY'),
+                string(credentialsId: "$EC2_REGION", variable: 'AWS_REGION')
                 ]) 
             {
                 dir('origin3-dev') {
@@ -120,8 +120,9 @@ node {
             	if (EC2_TERMINATE_INSTANCES) {
                 
                 	withCredentials([
-                    		string(credentialsId: "$EC2_ACCESS_KEY_ID", variable: 'AWS_ACCESS_KEY_ID'),
-				string(credentialsId: "$EC2_SECRET_ACCESS_KEY", variable: 'AWS_SECRET_ACCESS_KEY')
+                        string(credentialsId: "$EC2_ACCESS_KEY_ID", variable: 'AWS_ACCESS_KEY_ID'),
+                        string(credentialsId: "$EC2_SECRET_ACCESS_KEY", variable: 'AWS_SECRET_ACCESS_KEY'),
+                        string(credentialsId: "$EC2_REGION", variable: 'AWS_REGION')
                     	]) 
                 {
                     dir('origin3-dev') {

--- a/pipeline/ocp37-base
+++ b/pipeline/ocp37-base
@@ -46,7 +46,6 @@ node {
                 sh 'rm -f overrides.yml'
                 def overrides = ['ec2_key': "$EC2_KEY",
                     'ec2_private_key_file': "$KEYS_DIR/$EC2_PRIVATE_KEY_FILE",
-                    'ec2_region': "$EC2_REGION",
                     'ec2_instance_type': "$EC2_INSTANCE_TYPE",
                     'ec2_repo_create': false,
                     'openshift_setup_client_version': "$OPENSHIFT_VERSION",
@@ -65,7 +64,8 @@ node {
         stage('Deploy OCP3') {
             withCredentials([
                 string(credentialsId: "$EC2_ACCESS_KEY_ID", variable: 'AWS_ACCESS_KEY_ID'),
-                string(credentialsId: "$EC2_SECRET_ACCESS_KEY", variable: 'AWS_SECRET_ACCESS_KEY')
+                string(credentialsId: "$EC2_SECRET_ACCESS_KEY", variable: 'AWS_SECRET_ACCESS_KEY'),
+                string(credentialsId: "$EC2_REGION", variable: 'AWS_REGION')
                 ]) 
             {
                 dir('origin3-dev') {
@@ -121,7 +121,8 @@ node {
                 
                 	withCredentials([
                     		string(credentialsId: "$EC2_ACCESS_KEY_ID", variable: 'AWS_ACCESS_KEY_ID'),
-				string(credentialsId: "$EC2_SECRET_ACCESS_KEY", variable: 'AWS_SECRET_ACCESS_KEY')
+                            string(credentialsId: "$EC2_SECRET_ACCESS_KEY", variable: 'AWS_SECRET_ACCESS_KEY'),
+                            string(credentialsId: "$EC2_REGION", variable: 'AWS_REGION')
                     	]) 
                 {
                     dir('origin3-dev') {

--- a/pipeline/ocp39-base
+++ b/pipeline/ocp39-base
@@ -46,7 +46,6 @@ node {
                 sh 'rm -f overrides.yml'
                 def overrides = ['ec2_key': "$EC2_KEY",
                     'ec2_private_key_file': "$KEYS_DIR/$EC2_PRIVATE_KEY_FILE",
-                    'ec2_region': "$EC2_REGION",
                     'ec2_instance_type': "$EC2_INSTANCE_TYPE",
                     'ec2_repo_create': false,
                     'openshift_setup_client_version': "$OPENSHIFT_VERSION",
@@ -65,7 +64,8 @@ node {
         stage('Deploy OCP3') {
             withCredentials([
                 string(credentialsId: "$EC2_ACCESS_KEY_ID", variable: 'AWS_ACCESS_KEY_ID'),
-                string(credentialsId: "$EC2_SECRET_ACCESS_KEY", variable: 'AWS_SECRET_ACCESS_KEY')
+                string(credentialsId: "$EC2_SECRET_ACCESS_KEY", variable: 'AWS_SECRET_ACCESS_KEY'),
+                string(credentialsId: "$EC2_REGION", variable: 'AWS_REGION')
                 ]) 
             {
                 dir('origin3-dev') {
@@ -121,7 +121,8 @@ node {
                 
                 	withCredentials([
                     		string(credentialsId: "$EC2_ACCESS_KEY_ID", variable: 'AWS_ACCESS_KEY_ID'),
-				string(credentialsId: "$EC2_SECRET_ACCESS_KEY", variable: 'AWS_SECRET_ACCESS_KEY')
+                            string(credentialsId: "$EC2_SECRET_ACCESS_KEY", variable: 'AWS_SECRET_ACCESS_KEY'),
+                            string(credentialsId: "$EC2_REGION", variable: 'AWS_REGION')
                     	]) 
                 {
                     dir('origin3-dev') {


### PR DESCRIPTION
According to [docs](https://docs.ansible.com/ansible/latest/modules/ec2_module.html?highlight=ec2), `AWS_REGION` and `EC2_REGION` are both accountable as env variables for choosing `ec2_region` at ansible AWS resources tasks. Now `AWS_REGION` env variable is set for handling this problem.

This PR changes are related to https://github.com/fusor/origin3-dev/pull/38