### PR TITLE
Fixing the issue with AWS_REGION credentials.

### DIFF
--- a/pipeline/ocp310-base
+++ b/pipeline/ocp310-base
@@ -64,8 +64,7 @@ node {
         stage('Deploy OCP3') {
             withCredentials([
                 string(credentialsId: "$EC2_ACCESS_KEY_ID", variable: 'AWS_ACCESS_KEY_ID'),
-                string(credentialsId: "$EC2_SECRET_ACCESS_KEY", variable: 'AWS_SECRET_ACCESS_KEY'),
-                string(credentialsId: "$EC2_REGION", variable: 'AWS_REGION')
+                string(credentialsId: "$EC2_SECRET_ACCESS_KEY", variable: 'AWS_SECRET_ACCESS_KEY')
                 ]) 
             {
                 dir('origin3-dev') {
@@ -121,8 +120,7 @@ node {
                 
                 	withCredentials([
                     		string(credentialsId: "$EC2_ACCESS_KEY_ID", variable: 'AWS_ACCESS_KEY_ID'),
-                            string(credentialsId: "$EC2_SECRET_ACCESS_KEY", variable: 'AWS_SECRET_ACCESS_KEY'),
-                            string(credentialsId: "$EC2_REGION", variable: 'AWS_REGION')
+                            string(credentialsId: "$EC2_SECRET_ACCESS_KEY", variable: 'AWS_SECRET_ACCESS_KEY')
                     	]) 
                 {
                     dir('origin3-dev') {

--- a/pipeline/ocp311-base
+++ b/pipeline/ocp311-base
@@ -64,8 +64,7 @@ node {
         stage('Deploy OCP3') {
             withCredentials([
                 string(credentialsId: "$EC2_ACCESS_KEY_ID", variable: 'AWS_ACCESS_KEY_ID'),
-                string(credentialsId: "$EC2_SECRET_ACCESS_KEY", variable: 'AWS_SECRET_ACCESS_KEY'),
-                string(credentialsId: "$EC2_REGION", variable: 'AWS_REGION')
+                string(credentialsId: "$EC2_SECRET_ACCESS_KEY", variable: 'AWS_SECRET_ACCESS_KEY')
                 ]) 
             {
                 dir('origin3-dev') {
@@ -121,8 +120,7 @@ node {
                 
                 	withCredentials([
                         string(credentialsId: "$EC2_ACCESS_KEY_ID", variable: 'AWS_ACCESS_KEY_ID'),
-                        string(credentialsId: "$EC2_SECRET_ACCESS_KEY", variable: 'AWS_SECRET_ACCESS_KEY'),
-                        string(credentialsId: "$EC2_REGION", variable: 'AWS_REGION')
+                        string(credentialsId: "$EC2_SECRET_ACCESS_KEY", variable: 'AWS_SECRET_ACCESS_KEY')
                     	]) 
                 {
                     dir('origin3-dev') {

--- a/pipeline/ocp37-base
+++ b/pipeline/ocp37-base
@@ -64,8 +64,7 @@ node {
         stage('Deploy OCP3') {
             withCredentials([
                 string(credentialsId: "$EC2_ACCESS_KEY_ID", variable: 'AWS_ACCESS_KEY_ID'),
-                string(credentialsId: "$EC2_SECRET_ACCESS_KEY", variable: 'AWS_SECRET_ACCESS_KEY'),
-                string(credentialsId: "$EC2_REGION", variable: 'AWS_REGION')
+                string(credentialsId: "$EC2_SECRET_ACCESS_KEY", variable: 'AWS_SECRET_ACCESS_KEY')
                 ]) 
             {
                 dir('origin3-dev') {
@@ -121,8 +120,7 @@ node {
                 
                 	withCredentials([
                     		string(credentialsId: "$EC2_ACCESS_KEY_ID", variable: 'AWS_ACCESS_KEY_ID'),
-                            string(credentialsId: "$EC2_SECRET_ACCESS_KEY", variable: 'AWS_SECRET_ACCESS_KEY'),
-                            string(credentialsId: "$EC2_REGION", variable: 'AWS_REGION')
+                            string(credentialsId: "$EC2_SECRET_ACCESS_KEY", variable: 'AWS_SECRET_ACCESS_KEY')
                     	]) 
                 {
                     dir('origin3-dev') {

--- a/pipeline/ocp39-base
+++ b/pipeline/ocp39-base
@@ -64,8 +64,7 @@ node {
         stage('Deploy OCP3') {
             withCredentials([
                 string(credentialsId: "$EC2_ACCESS_KEY_ID", variable: 'AWS_ACCESS_KEY_ID'),
-                string(credentialsId: "$EC2_SECRET_ACCESS_KEY", variable: 'AWS_SECRET_ACCESS_KEY'),
-                string(credentialsId: "$EC2_REGION", variable: 'AWS_REGION')
+                string(credentialsId: "$EC2_SECRET_ACCESS_KEY", variable: 'AWS_SECRET_ACCESS_KEY')
                 ]) 
             {
                 dir('origin3-dev') {
@@ -121,8 +120,7 @@ node {
                 
                 	withCredentials([
                     		string(credentialsId: "$EC2_ACCESS_KEY_ID", variable: 'AWS_ACCESS_KEY_ID'),
-                            string(credentialsId: "$EC2_SECRET_ACCESS_KEY", variable: 'AWS_SECRET_ACCESS_KEY'),
-                            string(credentialsId: "$EC2_REGION", variable: 'AWS_REGION')
+                            string(credentialsId: "$EC2_SECRET_ACCESS_KEY", variable: 'AWS_SECRET_ACCESS_KEY')
                     	]) 
                 {
                     dir('origin3-dev') {


### PR DESCRIPTION
Pipelines now use EC2_REGION, can't use string variable as credentials as it is https://github.com/fusor/mig-ci/pull/57.