### PR TITLE
Allow mig-controller to be hosted on either OCP3 or OCP4 clusters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ tls/*
 keys/*
 bin/*
 kubeconfigs/*
+mig-controller/*
 config/velero_aws_creds.yml
 config/pull-secret
 config/mig_controller.yml

--- a/pipeline/ocp4-base.groovy
+++ b/pipeline/ocp4-base.groovy
@@ -46,12 +46,13 @@ node {
 
         common_stages.deployOCP4().call()
 
-        stage('Deploy mig-controller and mig-ui on target cluster') {
-            steps_finished << 'Deploy mig-controller and mig-ui on target cluster'
+        stage('Deploy mig-controller on target cluster') {
+            steps_finished << 'Deploy mig-controller on target cluster'
             withEnv(['PATH+EXTRA=~/bin', "KUBECONFIG=${KUBECONFIG_OCP4}"]) {
                 ansiColor('xterm') {
                     ansiblePlaybook(
                         playbook: 'mig_controller_deploy.yml',
+                        extras: "-e mig_controller_remote_cluster_online=false",
                         hostKeyChecking: false,
                         unbuffered: true,
                         colorized: true)

--- a/pipeline/parallel-base.groovy
+++ b/pipeline/parallel-base.groovy
@@ -81,12 +81,13 @@ node {
             }
         }
 
-        stage('Deploy mig-controller and mig-ui on source cluster') {
-            steps_finished << 'Deploy mig-controller and mig-ui on source cluster'
-            withEnv(['PATH+EXTRA=~/bin', "KUBECONFIG=${KUBECONFIG_OCP3}"]) {
+        stage('Deploy mig-controller on source cluster') {
+            steps_finished << 'Deploy mig-controller on source cluster'
+            withEnv(['PATH+EXTRA=~/bin', "KUBECONFIG=${KUBECONFIG_OCP3}", "CLUSTER_VERSION=3"]) {
                 ansiColor('xterm') {
                     ansiblePlaybook(
                         playbook: 'mig_controller_deploy.yml',
+                        extras: "-e mig_controller_host_cluster=false",
                         hostKeyChecking: false,
                         unbuffered: true,
                         colorized: true)
@@ -106,7 +107,6 @@ node {
                     ansiColor('xterm') {
                         ansiblePlaybook(
                             playbook: 'mig_controller_deploy.yml',
-                            extras: "-e with_controller=false",
                             hostKeyChecking: false,
                             unbuffered: true,
                             colorized: true)

--- a/roles/mig_controller_deploy/tasks/main.yml
+++ b/roles/mig_controller_deploy/tasks/main.yml
@@ -9,7 +9,8 @@
 
 - name: Deploy mig controller
   import_tasks: deploy.yml
-  when: with_controller
+  when: mig_controller_host_cluster
 
 - name: Process mig controller deployment summary
   import_tasks: summary.yml
+  when: mig_controller_host_cluster|bool and mig_controller_remote_cluster_online|bool

--- a/roles/mig_controller_prereqs/defaults/main.yml
+++ b/roles/mig_controller_prereqs/defaults/main.yml
@@ -2,3 +2,5 @@
 mig_controller_location: "{{ workspace }}/mig-controller"
 mig_controller_namespace: "mig"
 mig_controller_sa_name: "mig"
+mig_controller_host_cluster: true
+mig_controller_remote_cluster_online: true

--- a/roles/mig_controller_prereqs/tasks/apply_ocp3_fixes.yml
+++ b/roles/mig_controller_prereqs/tasks/apply_ocp3_fixes.yml
@@ -1,4 +1,4 @@
-# Apply misc cluster fixes for velero/restic integration
+# Apply misc cluster fixes for velero/restic integration on cluster_up deployments
 
 - name: Apply OCP3 fixes
   block:
@@ -12,6 +12,7 @@
         module: ec2_instance_facts
         filters:
           "tag:Name": "{{ ansible_user }}-origin3-dev"
+          "tag:creator_arn": "{{ caller_facts.arn }}"
       register: ec2_instance
 
     - name: Extract public ip

--- a/roles/mig_controller_prereqs/tasks/deploy_velero.yml
+++ b/roles/mig_controller_prereqs/tasks/deploy_velero.yml
@@ -25,10 +25,15 @@
   retries: 60
   delay: 5
 
-# Fix me: reconfigure when we move to OA based installations
+# Adjust host pod dir based on OCP3 deployment type
+
 - name: Fix restic pod dir mount for oc cluster up install
   shell: "{{ oc_binary }} set volume -n velero ds/restic --add --name=host-pods --path /tmp/openshift.local.clusterup/openshift.local.volumes/pods --overwrite"
-  when: deployment_type == 'cluster_up'
+  when: deployment_type == 'cluster_up' and cluster_version != '4'
+
+- name: Fix restic pod dir mount for OA install
+  shell: "{{ oc_binary }} set volume -n velero ds/restic --add --name=host-pods --path /var/lib/origin/openshift.local.volumes/pods --overwrite"
+  when: deployment_type == 'OA' and cluster_version != '4'
 
 - name: Check status of restic deployment
   k8s_facts:

--- a/roles/mig_controller_prereqs/tasks/main.yml
+++ b/roles/mig_controller_prereqs/tasks/main.yml
@@ -11,3 +11,4 @@
 
 - name: Prepare remote cluster
   import_tasks: prepare_remote_cluster.yml
+  when: mig_controller_host_cluster|bool and mig_controller_remote_cluster_online|bool

--- a/roles/mig_controller_prereqs/tasks/prepare_remote_cluster.yml
+++ b/roles/mig_controller_prereqs/tasks/prepare_remote_cluster.yml
@@ -1,10 +1,29 @@
 ---
+# OCP3 host clusters login to OCP4 for remote cluster tasks, the opposite for OCP4 host clusters.
+
 - name: Logging to OCP4 and saving credentials
   include_role:
     name: login_ocp
   vars:
     source_kubeconfig: "{{ playbook_dir }}/auth/kubeconfig"
     target_kubeconfig: "{{ ocp4_kubeconfig }}"
+  when: cluster_version == '3'
+
+- name: Logging to OCP3 and saving credentials
+  include_role:
+    name: login_ocp
+  vars:
+    source_kubeconfig: "{{ playbook_dir }}/kubeconfigs/kubeconfig"
+    target_kubeconfig: "{{ ocp3_kubeconfig }}"
+  when: cluster_version == '4'
+
+- set_fact:
+    remote_cluster_kubeconfig: "{{ ocp4_kubeconfig }}"
+  when: cluster_version == '3'
+
+- set_fact:
+    remote_cluster_kubeconfig: "{{ ocp3_kubeconfig }}"
+  when: cluster_version == '4'
 
 - name: Start remote cluster tasks
   block:
@@ -30,4 +49,4 @@
         msg: "Destination cluster URL set to: {{ dest_cluster_url }}"
 
   environment:
-    KUBECONFIG: "{{ ocp4_kubeconfig }}"
+    KUBECONFIG: "{{ remote_cluster_kubeconfig }}"


### PR DESCRIPTION
Introduce the ability to select which cluster will host the mig-controller, by default pipelines are set to deploy mig-controller now on OCP4 clusters. Another consideration when using these roles is that the remote cluster (not running the controller) has to always deploy first, this is in order to deploy velero and required SA. Once this is done, the host cluster will be able to fetch the SA token from the remote cluster afterwards.

Controlling variables : 

* mig_controller_host_cluster : determines if mig-controller will be deployed on this cluster (default yes)
* mig_controller_remote_cluster_online : determines if the remote cluster is currently online (default yes)
* cluster_version: This is required for OCP3 clusters and must be always set (default to 4)
* deployment_type: This is optional unless you are deploying on cluster_up deployments (default to OA)

Another consideration, ec2_region must always be set. By default lookups for AWS_REGION and EC2_REGION are performed.
  