### PR TITLE
Fixed repo path, added docker-build

### DIFF
--- a/pipeline/parallel-base.groovy
+++ b/pipeline/parallel-base.groovy
@@ -14,8 +14,10 @@ string(defaultValue: 'ocp-workshop', description: 'AgnosticD environment type to
 string(defaultValue: 'ci', description: 'EC2 SSH key name to deploy on instances for remote access ', name: 'EC2_KEY', trim: false),
 string(defaultValue: 'eu-west-1', description: 'AWS region to deploy instances', name: 'AWS_REGION', trim: false),
 string(defaultValue: 'agnosticd', description: 'Deployment type to choose', name: 'DEPLOYMENT_TYPE', trim: false),
-string(defaultValue: 'fusor', description: 'Mig controller repo to test', name: 'MIG_CONTROLLER_REPO', trim: false),
+string(defaultValue: 'https://github.com/fusor/mig-controller.git', description: 'Mig controller repo to test', name: 'MIG_CONTROLLER_REPO', trim: false),
 string(defaultValue: 'HEAD', description: 'Mig controller repo branch to test', name: 'MIG_CONTROLLER_BRANCH', trim: false),
+string(defaultValue: 'quay.io/fbladilo/mig-controller', description: 'Repo for quay io mig-controller images', name: 'QUAYIO_CI_REPO', trim: false),
+credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.UsernamePasswordMultiBinding', defaultValue: 'ci_quay_credentials', description: 'Credentials for quay.io container storage, used by mig-controller to push and pull images', name: 'QUAYIO_CREDENTIALS', required: true),
 credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl', defaultValue: 'agnosticd_own_repo', description: 'Private repo address for openshift-ansible packages', name: 'AGND_REPO', required: true),
 credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl', defaultValue: 'ci_aws_access_key_id', description: 'EC2 access key ID for auth purposes', name: 'EC2_ACCESS_KEY_ID', required: true),
 credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl', defaultValue: 'ci_aws_secret_access_key', description: 'EC2 private key needed to access instances, from Jenkins credentials store', name: 'EC2_SECRET_ACCESS_KEY', required: true),
@@ -58,6 +60,7 @@ node {
             utils.copy_private_keys()
             utils.copy_public_keys()
             utils.clone_related_repos()
+            utils.clone_mig_controller()
             if (env.DEPLOYMENT_TYPE == 'agnosticd') {
                 utils.prepare_agnosticd()
             } else if (env.DEPLOYMENT_TYPE != 'OA') {
@@ -121,6 +124,7 @@ node {
                         }
                 }
             if (CLEAN_WORKSPACE) {
+                utils.teardown_mig_controller()
                 cleanWs cleanWhenFailure: false, notFailBuild: true
             }
         }

--- a/pipeline/utils.groovy
+++ b/pipeline/utils.groovy
@@ -65,6 +65,12 @@ def prepare_origin3_dev() {
 }
 
 
+def clone_mig_controller() {
+  echo 'Cloning mig-controller repo'
+  checkout([$class: 'GitSCM', branches: [[name: "${MIG_CONTROLLER_BRANCH}"]], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'mig-controller']], submoduleCfg: [], userRemoteConfigs: [[url: "${MIG_CONTROLLER_REPO}"]]])
+}
+
+
 def prepare_agnosticd() {
   sh 'test -e ~/.local/bin/aws || pip install awscli --upgrade --user'
 
@@ -237,6 +243,13 @@ def teardown_nfs(prefix = '') {
         unbuffered: true,
         colorized: true)
     }
+  }
+}
+
+def teardown_mig_controller() {
+  // Check if is not upstream
+  if (env.QUAYIO_CI_REPO && "${MIG_CONTROLLER_REPO}" != "https://github.com/fusor/mig-controller.git") {
+    sh "docker rmi ${QUAYIO_CI_REPO}:${MIG_CONTROLLER_BRANCH}"
   }
 }
 

--- a/roles/mig_controller_prereqs/defaults/main.yml
+++ b/roles/mig_controller_prereqs/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 cluster_version: "{{ lookup('env', 'CLUSTER_VERSION') or '4' }}"
 mig_controller_location: "{{ workspace }}/mig-controller"
-mig_controller_owner_repo: "{{ lookup('env', 'MIG_CONTROLLER_REPO') or 'fusor' }}"
+mig_controller_owner_repo: "{{ lookup('env', 'MIG_CONTROLLER_REPO') or 'https://github.com/fusor/mig-controller.git' }}"
 mig_controller_owner_branch: "{{ lookup('env', 'MIG_CONTROLLER_BRANCH') or 'HEAD' }}"
 mig_controller_namespace: "mig"
 mig_controller_sa_name: "mig"

--- a/roles/mig_controller_prereqs/tasks/deploy_velero.yml
+++ b/roles/mig_controller_prereqs/tasks/deploy_velero.yml
@@ -1,7 +1,7 @@
 - name: Clone the mig controller repo
   git:
     dest: "{{ mig_controller_location }}"
-    repo: "https://github.com/{{ mig_controller_owner_repo }}/mig-controller.git"
+    repo: "{{ mig_controller_owner_repo }}"
     version: "{{ mig_controller_owner_branch }}"
     force: true
     depth: 1


### PR DESCRIPTION
This small fix exists for two reasons:
1) Test incoming PRs from `origin/some-branch` to `origin/master`.
2) Build mig-controller docker images and execute migration from pulled branch of PR.