### PR TITLE
Do not force git clone on mig_controller_prereqs

### DIFF
--- a/roles/mig_controller_prereqs/tasks/deploy_velero.yml
+++ b/roles/mig_controller_prereqs/tasks/deploy_velero.yml
@@ -3,8 +3,7 @@
     dest: "{{ mig_controller_location }}"
     repo: "{{ mig_controller_owner_repo }}"
     version: "{{ mig_controller_owner_branch }}"
-    force: true
-    depth: 1
+  ignore_errors: true
 
 - name: Deploy velero
   command: "{{ mig_controller_location }}/hack/deploy/deploy_velero.sh"


### PR DESCRIPTION
- Remove forced clone which causes conflicts when docker images are rebuilt on the cloned repo/branch
- Ignore errors if modified files are found on the clone, such in the case of rebuilt docker images