### PR TITLE
Configure IDP on OCP4 deployments

### DIFF
--- a/pipeline/common_stages.groovy
+++ b/pipeline/common_stages.groovy
@@ -236,8 +236,8 @@ def provision_pvs(kubeconfig, prefix = '') {
     prefix = "-e prefix=${prefix}"
   }
   return {
-    stage('Provison PVs on source cluster') {
-      steps_finished << 'Provison PVs on source cluster'
+    stage('Provision PVs on source cluster') {
+      steps_finished << 'Provision PVs on source cluster'
       def skip_tags = ""
       if (env.DEPLOYMENT_TYPE == 'agnosticd') {
         skip_tags = "remove_existing_pvs"

--- a/pipeline/common_stages.groovy
+++ b/pipeline/common_stages.groovy
@@ -184,7 +184,8 @@ def deployOCP4(kubeconfig) {
       steps_finished << 'Deploy OCP4 ' + OCP4_VERSION
       withCredentials([
           string(credentialsId: "$EC2_ACCESS_KEY_ID", variable: 'AWS_ACCESS_KEY_ID'),
-          string(credentialsId: "$EC2_SECRET_ACCESS_KEY", variable: 'AWS_SECRET_ACCESS_KEY')
+          string(credentialsId: "$EC2_SECRET_ACCESS_KEY", variable: 'AWS_SECRET_ACCESS_KEY'),
+          UsernamePasswordMultiBinding(credentialsId: "${OCP4_CREDENTIALS}", usernameVariable: 'OCP4_ADMIN_USER', passwordVariable: 'OCP4_ADMIN_PASSWD')
           ])
       {
         withEnv(["KUBECONFIG=${kubeconfig}", "CLUSTER_NAME=${CLUSTER_NAME}-v4-${BUILD_NUMBER}"]){

--- a/pipeline/common_stages.groovy
+++ b/pipeline/common_stages.groovy
@@ -185,7 +185,7 @@ def deployOCP4(kubeconfig) {
       withCredentials([
           string(credentialsId: "$EC2_ACCESS_KEY_ID", variable: 'AWS_ACCESS_KEY_ID'),
           string(credentialsId: "$EC2_SECRET_ACCESS_KEY", variable: 'AWS_SECRET_ACCESS_KEY'),
-          UsernamePasswordMultiBinding(credentialsId: "${OCP4_CREDENTIALS}", usernameVariable: 'OCP4_ADMIN_USER', passwordVariable: 'OCP4_ADMIN_PASSWD')
+          [$class: 'UsernamePasswordMultiBinding', credentialsId: "${OCP4_CREDENTIALS}", usernameVariable: 'OCP4_ADMIN_USER', passwordVariable: 'OCP4_ADMIN_PASSWD']
           ])
       {
         withEnv(["KUBECONFIG=${kubeconfig}", "CLUSTER_NAME=${CLUSTER_NAME}-v4-${BUILD_NUMBER}"]){

--- a/pipeline/ocp4-base.groovy
+++ b/pipeline/ocp4-base.groovy
@@ -51,19 +51,11 @@ node {
         currentBuild.result = "FAILED"
         println(ex.toString())
     } finally {
+        // Success or failure, always send notifications
         utils.notifyBuild(currentBuild.result)
         stage('Clean Up Environment') {
         // Always attempt to terminate instances if EC2_TERMINATE_INSTANCES is true
-          if (EC2_TERMINATE_INSTANCES) {
-            withCredentials([
-              string(credentialsId: "$EC2_ACCESS_KEY_ID", variable: 'AWS_ACCESS_KEY_ID'),
-              string(credentialsId: "$EC2_SECRET_ACCESS_KEY", variable: 'AWS_SECRET_ACCESS_KEY')
-              ])
-            {
-              utils.teardown_OCP4()
-            }
-          }
-
+          utils.teardown_OCP4()
           if (CLEAN_WORKSPACE) {
             cleanWs cleanWhenFailure: false, notFailBuild: true
           }

--- a/pipeline/ocp4-base.groovy
+++ b/pipeline/ocp4-base.groovy
@@ -9,6 +9,7 @@ credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.StringC
 credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl', defaultValue: 'ci_aws_secret_access_key', description: 'EC2 private key needed to access instances, from Jenkins credentials store', name: 'EC2_SECRET_ACCESS_KEY', required: true),
 credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.FileCredentialsImpl', defaultValue: 'ci_pull_secret', description: 'Pull secret needed for OCP4 deployments', name: 'OCP4_PULL_SECRET', required: true),
 credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.FileCredentialsImpl', defaultValue: 'ci_pub_key', description: 'EC2 public key needed for OCP4 instances', name: 'EC2_PUB_KEY', required: true),
+credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.UsernamePasswordMultiBinding', defaultValue: 'ci_ocp4_admin_credentials', description: 'Cluster admin credentials used in OCP4 deployments', name: 'OCP4_CREDENTIALS', required: true),
 string(defaultValue: 'ci', description: 'EC2 SSH key name to deploy on instances for remote access ', name: 'EC2_KEY', trim: false),
 string(defaultValue: 'eu-west-1', description: 'AWS region to deploy instances', name: 'AWS_REGION', trim: false),
 booleanParam(defaultValue: true, description: 'Clean up workspace after build', name: 'CLEAN_WORKSPACE'),

--- a/pipeline/ocp4-base.groovy
+++ b/pipeline/ocp4-base.groovy
@@ -51,14 +51,22 @@ node {
         currentBuild.result = "FAILED"
         println(ex.toString())
     } finally {
-        // Success or failure, always send notifications
         utils.notifyBuild(currentBuild.result)
         stage('Clean Up Environment') {
-        // Success or failure, always terminate instances if requested
-            utils.teardown_OCP4()
-            if (CLEAN_WORKSPACE) {
-                cleanWs cleanWhenFailure: false, notFailBuild: true
+        // Always attempt to terminate instances if EC2_TERMINATE_INSTANCES is true
+          if (EC2_TERMINATE_INSTANCES) {
+            withCredentials([
+              string(credentialsId: "$EC2_ACCESS_KEY_ID", variable: 'AWS_ACCESS_KEY_ID'),
+              string(credentialsId: "$EC2_SECRET_ACCESS_KEY", variable: 'AWS_SECRET_ACCESS_KEY')
+              ])
+            {
+              utils.teardown_OCP4()
             }
+          }
+
+          if (CLEAN_WORKSPACE) {
+            cleanWs cleanWhenFailure: false, notFailBuild: true
+          }
         }
-	}
+      }
 }

--- a/pipeline/parallel-base.groovy
+++ b/pipeline/parallel-base.groovy
@@ -27,6 +27,7 @@ credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.FileCre
 credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl', defaultValue: 'ci_rhel_sub_user', description: 'RHEL Openshift subscription account username', name: 'EC2_SUB_USER', required: true),
 credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl', defaultValue: 'ci_rhel_sub_pass', description: 'RHEL Openshift subscription account password', name: 'EC2_SUB_PASS', required: true),
 credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.FileCredentialsImpl', defaultValue: 'ci_pull_secret', description: 'Pull secret needed for OCP4 deployments', name: 'OCP4_PULL_SECRET', required: true),
+credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.UsernamePasswordMultiBinding', defaultValue: 'ci_ocp4_admin_credentials', description: 'Cluster admin credentials used in OCP4 deployments', name: 'OCP4_CREDENTIALS', required: true),
 booleanParam(defaultValue: true, description: 'Clean up workspace after build', name: 'CLEAN_WORKSPACE'),
 booleanParam(defaultValue: true, description: 'EC2 terminate instances after build', name: 'EC2_TERMINATE_INSTANCES')])])
 

--- a/roles/ocp4_cluster_deploy/defaults/main.yml
+++ b/roles/ocp4_cluster_deploy/defaults/main.yml
@@ -1,3 +1,6 @@
 openshift_installer_release: "4.1.4"
 openshift_installer_release_type: "linux"
 openshift_installer_release_url: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{ openshift_installer_release }}/openshift-install-{{ openshift_installer_release_type }}-{{ openshift_installer_release }}.tar.gz"
+ocp4_admin_user:  "{{ lookup('env', 'OCP4_ADMIN_USER') or 'admin' }}"
+ocp4_admin_password:  "{{ lookup('env', 'OCP4_ADMIN_PASSWD') or 'r3dh4t1!' }}"
+ocp4_htpasswd_file: "{{ playbook_dir }}/ocp4-htpasswd"

--- a/roles/ocp4_cluster_deploy/files/htpasswd_idp.yml
+++ b/roles/ocp4_cluster_deploy/files/htpasswd_idp.yml
@@ -1,0 +1,12 @@
+apiVersion: config.openshift.io/v1
+kind: OAuth
+metadata:
+  name: cluster
+spec:
+  identityProviders:
+  - name: my_htpasswd_provider 
+    mappingMethod: claim 
+    type: HTPasswd
+    htpasswd:
+      fileData:
+        name: htpass-secret

--- a/roles/ocp4_cluster_deploy/tasks/idp.yml
+++ b/roles/ocp4_cluster_deploy/tasks/idp.yml
@@ -19,6 +19,8 @@
   shell: "{{ oc_binary }} login -u {{ ocp4_admin_user }} -p {{ ocp4_admin_password }} --insecure-skip-tls-verify=true"
   retries: 6
   delay: 10
+  register: result
+  until: result is succeeded
 
 - name: Remove temporary httpasswd file
   file:

--- a/roles/ocp4_cluster_deploy/tasks/idp.yml
+++ b/roles/ocp4_cluster_deploy/tasks/idp.yml
@@ -11,13 +11,14 @@
   k8s:
     state: present
     definition: "{{ lookup('file', 'htpasswd_idp.yml')}}"
+    wait: yes
 
 - name: Add cluster-admin role to {{ ocp4_admin_user }}
   shell: "{{ oc_binary }} adm policy add-cluster-role-to-user cluster-admin {{ ocp4_admin_user }}"
 
 - name: Login as {{ ocp4_admin_user }}
   shell: "{{ oc_binary }} login -u {{ ocp4_admin_user }} -p {{ ocp4_admin_password }} --insecure-skip-tls-verify=true"
-  retries: 6
+  retries: 12
   delay: 10
   register: result
   until: result is succeeded

--- a/roles/ocp4_cluster_deploy/tasks/idp.yml
+++ b/roles/ocp4_cluster_deploy/tasks/idp.yml
@@ -1,0 +1,26 @@
+- name: Create temporary htpasswd file
+  htpasswd:
+    path: "{{ ocp4_htpasswd_file }}"
+    name: "{{ ocp4_admin_user }}"
+    password: "{{ ocp4_admin_password }}"
+
+- name: Create htpasswd secret
+  shell: "oc create secret generic htpass-secret --from-file=htpasswd={{ ocp4_htpasswd_file }} -n openshift-config"
+    
+- name: Create htpasswd IDP
+  k8s:
+    state: present
+    definition: "{{ lookup('file', 'htpasswd_idp.yml')}}"
+
+- name: Add cluster-admin role to {{ ocp4_admin_user }}
+  shell: "oc adm policy add-cluster-role-to-user cluster-admin {{ ocp4_admin_user }}"
+
+- name: Login as {{ ocp4_admin_user }}
+  shell: "oc login -u {{ ocp4_admin_user }} -p {{ ocp4_admin_password }} --insecure-skip-tls-verify=true"
+  retries: 6
+  delay: 10
+
+- name: Remove temporary httpasswd file
+  file:
+    path: "{{ ocp4_htpasswd_file }}"
+    state: absent

--- a/roles/ocp4_cluster_deploy/tasks/idp.yml
+++ b/roles/ocp4_cluster_deploy/tasks/idp.yml
@@ -5,7 +5,7 @@
     password: "{{ ocp4_admin_password }}"
 
 - name: Create htpasswd secret
-  shell: "oc create secret generic htpass-secret --from-file=htpasswd={{ ocp4_htpasswd_file }} -n openshift-config"
+  shell: "{{ oc_binary }} create secret generic htpass-secret --from-file=htpasswd={{ ocp4_htpasswd_file }} -n openshift-config"
     
 - name: Create htpasswd IDP
   k8s:
@@ -13,10 +13,10 @@
     definition: "{{ lookup('file', 'htpasswd_idp.yml')}}"
 
 - name: Add cluster-admin role to {{ ocp4_admin_user }}
-  shell: "oc adm policy add-cluster-role-to-user cluster-admin {{ ocp4_admin_user }}"
+  shell: "{{ oc_binary }} adm policy add-cluster-role-to-user cluster-admin {{ ocp4_admin_user }}"
 
 - name: Login as {{ ocp4_admin_user }}
-  shell: "oc login -u {{ ocp4_admin_user }} -p {{ ocp4_admin_password }} --insecure-skip-tls-verify=true"
+  shell: "{{ oc_binary }} login -u {{ ocp4_admin_user }} -p {{ ocp4_admin_password }} --insecure-skip-tls-verify=true"
   retries: 6
   delay: 10
 

--- a/roles/ocp4_cluster_deploy/tasks/main.yml
+++ b/roles/ocp4_cluster_deploy/tasks/main.yml
@@ -1,7 +1,7 @@
 - import_tasks: get_ocp4_installer.yml
-  tags: get_ocp4_installer
 
 - import_tasks: launch_ocp4_installer.yml
-  tags: launch_ocp4_installer
 
 - import_tasks: login.yml
+
+- import_tasks: idp.yml

--- a/roles/ocp4_prereqs/tasks/ocp4_prereqs.yml
+++ b/roles/ocp4_prereqs/tasks/ocp4_prereqs.yml
@@ -32,8 +32,10 @@
   shell: "{{ playbook_dir }}/openshift-install destroy cluster"
   when: install.stat.exists == true and terraform.stat.exists == true
 
-- name: Delete terraform.tfstate from unsuccessful deployment
-  shell: "rm -f {{ playbook_dir }}/terraform.tfstate"
+- name: delete terraform.tfstate from unsuccessful deployment
+  file:
+    path: "{{ playbook_dir }}/terraform.tfstate"
+    state: absent
 
 - name: template install file
   template:


### PR DESCRIPTION
Configure a htpasswd IDP on OCP4 deployments, it also creates a cluster-admin account that CI has full control of. 

- OCP4 cluster admin credentials are now defined in Jenkins credentials store
- OCP4 cluster is provisioned with kubeadmin and then switched to a cluster admin account created using IDP
-  Tested with ocp4-based and parallel-base pipelines

