### PR TITLE
Implement stable cluster pipeline for e2e CI flows

### DIFF
--- a/mig_controller_destroy.yml
+++ b/mig_controller_destroy.yml
@@ -1,0 +1,5 @@
+- hosts: localhost
+  roles:
+    - mig_controller_destroy
+  vars_files:
+    - "{{ playbook_dir }}/config/defaults.yml"

--- a/pipeline/common_stages.groovy
+++ b/pipeline/common_stages.groovy
@@ -320,7 +320,8 @@ def login_cluster(
       "console_addr": "${cluster_url}",
       "user": "${cluster_user}",
       "passwd": "${cluster_password}",
-      "kubeconfig": "${kubeconfig}"
+      "kubeconfig": "${kubeconfig}",
+      "force_login": "true"
       ]
      sh 'rm -f ocp_login_vars.yml'
      writeYaml file: 'ocp_login_vars.yml', data: ocp_login_vars

--- a/pipeline/common_stages.groovy
+++ b/pipeline/common_stages.groovy
@@ -306,6 +306,36 @@ def sanity_checks(kubeconfig) {
   }
 }
 
+def login_cluster(
+  cluster_url,
+  cluster_user,
+  cluster_password,
+  cluster_version,
+  kubeconfig) {
+
+  return {
+    stage("Login to OCP ${cluster_version}") {
+      steps_finished << 'Login to OCP ' + cluster_version
+      def ocp_login_vars = [
+      "console_addr": "${cluster_url}",
+      "user": "${cluster_user}",
+      "passwd": "${cluster_password}",
+      "kubeconfig": "${kubeconfig}"
+      ]
+     sh 'rm -f ocp_login_vars.yml'
+     writeYaml file: 'ocp_login_vars.yml', data: ocp_login_vars
+     ocp_login_vars = ocp_login_vars.collect { e -> '-e ' + e.key + '=' + e.value }
+     ansiColor('xterm') {
+       ansiblePlaybook(
+         playbook: 'login.yml',
+         extras: "${ocp_login_vars.join(' ')}",
+         hostKeyChecking: false,
+         unbuffered: true,
+         colorized: true)
+        }
+    }
+  }
+}
 
 def deploy_mig_controller_on_both(
   source_kubeconfig,

--- a/pipeline/mig-e2e-base.groovy
+++ b/pipeline/mig-e2e-base.groovy
@@ -1,0 +1,83 @@
+// parallel-base.groovy
+
+// Set Job properties and triggers
+properties([
+parameters([string(defaultValue: 'v3.11', description: 'OCP3 version to test', name: 'OCP3_VERSION', trim: false),
+string(defaultValue: 'v4.1', description: 'OCP4 version to test', name: 'OCP4_VERSION', trim: false),
+string(defaultValue: '', description: 'OCP3 source cluster API endpoint', name: 'OCP3_CLUSTER_URL', trim: false, required: true),
+string(defaultValue: '', description: 'OCP4 destination cluster API endpoint', name: 'OCP4_CLUSTER_URL', trim: false, required: true),
+string(defaultValue: 'eu-west-1', description: 'AWS region where clusters are deployed', name: 'AWS_REGION', trim: false),
+string(defaultValue: 'https://github.com/fusor/mig-controller.git', description: 'Mig controller repo to test', name: 'MIG_CONTROLLER_REPO', trim: false),
+string(defaultValue: 'master', description: 'Mig controller repo branch to test', name: 'MIG_CONTROLLER_BRANCH', trim: false),
+string(defaultValue: 'https://github.com/fusor/mig-e2e.git', description: 'Mig e2e repo to test', name: 'MIG_E2E_REPO', trim: false),
+string(defaultValue: 'master', description: 'Mig e2e repo branch to test', name: 'MIG_E2E_BRANCH', trim: false),
+string(defaultValue: 'all', description: 'e2e test tags to run, see https://github.com/fusor/mig-e2e for details, space delimited', name: 'E2E_TESTS', trim: false),
+string(defaultValue: 'quay.io/fbladilo/mig-controller', description: 'Repo for quay io mig-controller images', name: 'QUAYIO_CI_REPO', trim: false),
+credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.UsernamePasswordMultiBinding', defaultValue: 'ci_quay_credentials', description: 'Credentials for quay.io container storage, used by mig-controller to push and pull images', name: 'QUAYIO_CREDENTIALS', required: true),
+credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl', defaultValue: 'ci_aws_access_key_id', description: 'EC2 access key ID for auth purposes', name: 'EC2_ACCESS_KEY_ID', required: true),
+credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl', defaultValue: 'ci_aws_secret_access_key', description: 'EC2 private key needed to access instances, from Jenkins credentials store', name: 'EC2_SECRET_ACCESS_KEY', required: true),
+credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.UsernamePasswordMultiBinding', defaultValue: 'ci_ocp4_admin_credentials', description: 'Cluster admin credentials used in OCP4 deployments', name: 'OCP4_CREDENTIALS', required: true),
+credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.UsernamePasswordMultiBinding', defaultValue: 'ci_ocp3_admin_credentials', description: 'Cluster admin credentials used in OCP3 deployments', name: 'OCP3_CREDENTIALS', required: true),
+booleanParam(defaultValue: true, description: 'Clean up workspace after build', name: 'CLEAN_WORKSPACE')])])
+
+// true/false build parameter that defines if we cleanup workspace once build is done
+def CLEAN_WORKSPACE = params.CLEAN_WORKSPACE
+// Split e2e tests from string param
+def E2E_TESTS = params.E2E_TESTS.split(' ')
+
+def common_stages
+def utils
+
+steps_finished = []
+
+echo "Running job ${env.JOB_NAME}, build ${env.BUILD_ID} on ${env.JENKINS_URL}"
+echo "Build URL ${env.BUILD_URL}"
+echo "Job URL ${env.JOB_URL}"
+
+node {
+    sh "mkdir ${WORKSPACE}-${BUILD_NUMBER}"
+    ws("${WORKSPACE}-${BUILD_NUMBER}") {
+    try {
+        checkout scm
+        common_stages = load "${env.WORKSPACE}/pipeline/common_stages.groovy"
+        utils = load "${env.WORKSPACE}/pipeline/utils.groovy"
+
+        utils.notifyBuild('STARTED')
+
+        stage('Setup e2e environment') {
+            steps_finished << 'Setup e2e environment'
+
+            utils.prepare_workspace("${env.OCP3_VERSION}", "${env.OCP4_VERSION}")
+            utils.clone_mig_e2e()
+            utils.clone_mig_controller()
+        }
+
+        withCredentials([
+          [$class: 'UsernamePasswordMultiBinding', credentialsId: "${OCP3_CREDENTIALS}", usernameVariable: 'OCP3_ADMIN_USER', passwordVariable: 'OCP3_ADMIN_PASSWD'],
+          [$class: 'UsernamePasswordMultiBinding', credentialsId: "${OCP4_CREDENTIALS}", usernameVariable: 'OCP4_ADMIN_USER', passwordVariable: 'OCP4_ADMIN_PASSWD']
+          ]) {
+              common_stages.login_cluster("${env.OCP3_CLUSTER_URL}", "${env.OCP3_ADMIN_USER}", "${env.OCP3_ADMIN_PASSWD}", "${env.OCP3_VERSION}", SOURCE_KUBECONFIG).call()
+              common_stages.login_cluster("${env.OCP4_CLUSTER_URL}", "${env.OCP4_ADMIN_USER}", "${env.OCP4_ADMIN_PASSWD}", "${env.OCP4_VERSION}", TARGET_KUBECONFIG).call()
+             }
+        // Always ensure mig controller environment is clean before deployment
+        utils.teardown_mig_controller(SOURCE_KUBECONFIG)
+        utils.teardown_mig_controller(TARGET_KUBECONFIG)
+
+        // Deploy mig controller and begin tests
+        common_stages.deploy_mig_controller_on_both(SOURCE_KUBECONFIG, TARGET_KUBECONFIG, false, true).call()
+        common_stages.execute_migration(E2E_TESTS, SOURCE_KUBECONFIG, TARGET_KUBECONFIG).call()
+
+    } catch (Exception ex) {
+        currentBuild.result = "FAILED"
+        println(ex.toString())
+    } finally {
+        // Success or failure, always send notifications
+        utils.notifyBuild(currentBuild.result)
+        stage('Clean Up Environment') {
+          if (CLEAN_WORKSPACE) {
+              cleanWs cleanWhenFailure: false, notFailBuild: true
+          }
+        }
+      }
+    }
+}

--- a/pipeline/mig-e2e-base.groovy
+++ b/pipeline/mig-e2e-base.groovy
@@ -6,7 +6,7 @@ parameters([string(defaultValue: 'v3.11', description: 'OCP3 version to test', n
 string(defaultValue: 'v4.1', description: 'OCP4 version to test', name: 'OCP4_VERSION', trim: false),
 string(defaultValue: '', description: 'OCP3 source cluster API endpoint', name: 'OCP3_CLUSTER_URL', trim: false, required: true),
 string(defaultValue: '', description: 'OCP4 destination cluster API endpoint', name: 'OCP4_CLUSTER_URL', trim: false, required: true),
-string(defaultValue: 'eu-west-1', description: 'AWS region where clusters are deployed', name: 'AWS_REGION', trim: false),
+string(defaultValue: '', description: 'AWS region where clusters are deployed', name: 'AWS_REGION', trim: false, required: true),
 string(defaultValue: 'https://github.com/fusor/mig-controller.git', description: 'Mig controller repo to test', name: 'MIG_CONTROLLER_REPO', trim: false),
 string(defaultValue: 'master', description: 'Mig controller repo branch to test', name: 'MIG_CONTROLLER_BRANCH', trim: false),
 string(defaultValue: 'https://github.com/fusor/mig-e2e.git', description: 'Mig e2e repo to test', name: 'MIG_E2E_REPO', trim: false),

--- a/pipeline/parallel-base.groovy
+++ b/pipeline/parallel-base.groovy
@@ -128,7 +128,7 @@ node {
                         }
                 }
             if (CLEAN_WORKSPACE) {
-                utils.teardown_mig_controller()
+                utils.teardown_container_image()
                 cleanWs cleanWhenFailure: false, notFailBuild: true
             }
         }

--- a/pipeline/utils.groovy
+++ b/pipeline/utils.groovy
@@ -45,6 +45,10 @@ def clone_related_repos() {
   checkout([$class: 'GitSCM', branches: [[name: '*/master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'ocp-mig-test-data']], submoduleCfg: [], userRemoteConfigs: [[url: 'https://github.com/fusor/ocp-mig-test-data.git']]])
 }
 
+def clone_mig_e2e() {
+  echo 'Cloning mig-e2e repo'
+  checkout([$class: 'GitSCM', branches: [[name: "${MIG_E2E_BRANCH}"]], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'mig-e2e']], submoduleCfg: [], userRemoteConfigs: [[url: "${MIG_E2E_REPO}"]]])
+}
 
 def prepare_cpma(repo = '', branch = '') {
   if (repo == '') {
@@ -256,7 +260,19 @@ def teardown_nfs(prefix = '') {
   }
 }
 
-def teardown_mig_controller() {
+def teardown_mig_controller(kubeconfig) {
+  withEnv([ "KUBECONFIG=${kubeconfig}" ]) {
+    ansiColor('xterm') {
+      ansiblePlaybook(
+        playbook: 'mig_controller_destroy.yml',
+        hostKeyChecking: false,
+        unbuffered: true,
+        colorized: true)
+    }
+  }
+}
+
+def teardown_container_image() {
   // Check if is not upstream
   if (env.QUAYIO_CI_REPO && "${MIG_CONTROLLER_REPO}" != "https://github.com/fusor/mig-controller.git") {
     ansiColor('xterm') {

--- a/roles/login_ocp/defaults/main.yml
+++ b/roles/login_ocp/defaults/main.yml
@@ -3,7 +3,7 @@
 user: admin # Username for cluster login
 passwd: admin # Password for cluster login
 console_addr: '' # User specified cluster address
-force_login: False # Login into cluster anyway with provided credentials
+force_login: false # Login into cluster anyway with provided credentials
 
 # Kubeconfig processing
 kubeconfig: "{{ lookup('env', 'KUBECONFIG') or '~/.kube/config' }}"

--- a/roles/login_ocp/tasks/login.yml
+++ b/roles/login_ocp/tasks/login.yml
@@ -4,6 +4,7 @@
   environment:
     KUBECONFIG: "{{ kubeconfig }}"
   ignore_errors: true
+  when: not force_login|bool
 
 - block:
   - assert:
@@ -20,4 +21,4 @@
     until: login.rc == 0
     environment:
       KUBECONFIG: "{{ kubeconfig }}"
-  when: oc_status is failed or oc_status.rc != 0 or force_login == True
+    when: (oc_status is defined and oc_status is failed) or force_login|bool

--- a/roles/mig_controller_destroy/defaults/main.yml
+++ b/roles/mig_controller_destroy/defaults/main.yml
@@ -1,0 +1,14 @@
+---
+velero_crds:
+  - backups.velero.io
+  - backupstoragelocations.velero.io
+  - deletebackuprequests.velero.io
+  - downloadrequests.velero.io
+  - migrationcontrollers.migration.openshift.io
+  - podvolumebackups.velero.io
+  - podvolumerestores.velero.io
+  - resticrepositories.velero.io
+  - restores.velero.io
+  - schedules.velero.io
+  - serverstatusrequests.velero.io
+  - volumesnapshotlocations.velero.io

--- a/roles/mig_controller_destroy/tasks/main.yml
+++ b/roles/mig_controller_destroy/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+- name: Destroy mig namespace
+  k8s:
+    state: absent
+    api_version: v1
+    kind: Namespace
+    name: mig
+    wait: yes
+
+- name: Destroy velero CRDs
+  k8s:
+    state: absent
+    api_version: v1beta1
+    kind: CustomResourceDefinition
+    name: "{{ item }}"
+    wait: yes
+  with_items: "{{ velero_crds }}"


### PR DESCRIPTION
This pipeline is meant to be called by trigger scripts that supply the necessary parameters for an e2e CI flow. By default source and destination cluster API endpoints (stable clusters) along with AWS_REGION must be suppied in order to run.

Pipeline flow : 
* Prepares e2e environment
* Login to both clusters
* Destroys mig-controller on both clusters
* Deploys mig-controller on both clusters
* Executes tests

The pipeline takes around 20 minutes , down from almost 2 hours for a full build when using mig-parallel-base.
