### PR TITLE
Enable public NFS on agnosticd deployments

### DIFF
--- a/pipeline/common_stages.groovy
+++ b/pipeline/common_stages.groovy
@@ -120,6 +120,8 @@ def deploy_ocp3_agnosticd(kubeconfig) {
             'email': "${EMAIL}",
             'output_dir': "${WORKSPACE}",
             "update_packages": "false",
+            "support_instance_public_dns": "true",
+            "nfs_server_address": "support1.${CLUSTER_NAME}-v3-${BUILD_NUMBER}${BASESUFFIX}",
             // User admin to preserve consistency between different deployment types
             'admin_user': "${cluster_adm_user}",
             // Fix for commit # 8780932 to work

--- a/pipeline/ocp3-agnosticd-base.groovy
+++ b/pipeline/ocp3-agnosticd-base.groovy
@@ -24,6 +24,8 @@ booleanParam(defaultValue: true, description: 'EC2 terminate instances after bui
 
 // true/false build parameter that defines if we terminate instances once build is done
 def EC2_TERMINATE_INSTANCES = params.EC2_TERMINATE_INSTANCES
+// true/false build parameter that defines if we cleanup workspace once build is done
+def CLEAN_WORKSPACE = params.CLEAN_WORKSPACE
 
 def common_stages
 def utils
@@ -68,8 +70,12 @@ node {
         // Success or failure, always send notifications
         utils.notifyBuild(currentBuild.result)
         stage('Clean Up Environment') {
+          if (EC2_TERMINATE_INSTANCES) {
             utils.teardown_ocp3_agnosticd()
+          }
+          if (CLEAN_WORKSPACE) {
             cleanWs cleanWhenFailure: false, notFailBuild: true
+          }
         }
-    }
+     }
 }

--- a/pipeline/ocp3-agnosticd-base.groovy
+++ b/pipeline/ocp3-agnosticd-base.groovy
@@ -20,6 +20,7 @@ credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.FileCre
 credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.FileCredentialsImpl', defaultValue: 'ci_pub_key', description: 'EC2 public key needed for agnosticd instances', name: 'EC2_PUB_KEY', required: true),
 credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl', defaultValue: 'ci_rhel_sub_user', description: 'RHEL Openshift subscription account username', name: 'EC2_SUB_USER', required: true),
 credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl', defaultValue: 'ci_rhel_sub_pass', description: 'RHEL Openshift subscription account password', name: 'EC2_SUB_PASS', required: true),
+booleanParam(defaultValue: true, description: 'Clean up workspace after build', name: 'CLEAN_WORKSPACE'),
 booleanParam(defaultValue: true, description: 'EC2 terminate instances after build', name: 'EC2_TERMINATE_INSTANCES')])])
 
 // true/false build parameter that defines if we terminate instances once build is done

--- a/pipeline/parallel-base.groovy
+++ b/pipeline/parallel-base.groovy
@@ -83,14 +83,18 @@ node {
                     common_stages.deploy_origin3_dev(SOURCE_KUBECONFIG).call()
                 }
             }, deploy_NFS: {
+                if (env.DEPLOYMENT_TYPE != 'agnosticd') {
                 common_stages.deploy_NFS(CLUSTER_NAME + '-' + BUILD_NUMBER).call()
+                }
             }, deploy_OCP4: {
                 common_stages.deployOCP4(TARGET_KUBECONFIG).call()
             },
             failFast: true
         }
 
-        common_stages.provision_pvs(SOURCE_KUBECONFIG, CLUSTER_NAME + '-' + BUILD_NUMBER).call()
+        if (env.DEPLOYMENT_TYPE != 'agnosticd') {
+           common_stages.provision_pvs(SOURCE_KUBECONFIG, CLUSTER_NAME + '-' + BUILD_NUMBER).call()
+        }
 
         common_stages.deploy_mig_controller_on_both(SOURCE_KUBECONFIG, TARGET_KUBECONFIG, false, true).call()
 
@@ -122,7 +126,9 @@ node {
                                 }, destroy_OCP4: {
                                     utils.teardown_OCP4()
                                 }, destroy_NFS: {
-                                    utils.teardown_nfs(CLUSTER_NAME + '-' + BUILD_NUMBER)
+                                    if (env.DEPLOYMENT_TYPE != 'agnosticd') {
+                                       utils.teardown_nfs(CLUSTER_NAME + '-' + BUILD_NUMBER)
+                                    }
                                 }, failFast: false
                             }
                         }

--- a/pipeline/utils.groovy
+++ b/pipeline/utils.groovy
@@ -91,7 +91,7 @@ def prepare_agnosticd() {
 
   sh 'rm -f agnosticd/ansible.cfg'
 
-  checkout([$class: 'GitSCM', branches: [[name: '8780932ab2917e000b7b05297a7a63d0b7397a28']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'agnosticd']], submoduleCfg: [], userRemoteConfigs: [[url: 'https://github.com/redhat-cop/agnosticd.git']]])
+  checkout([$class: 'GitSCM', branches: [[name: 'development']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'agnosticd']], submoduleCfg: [], userRemoteConfigs: [[url: 'https://github.com/redhat-cop/agnosticd.git']]])
 
   // Fixes
   withCredentials([file(credentialsId: "${env.EC2_PUB_KEY}", variable: "SSH_PUB_KEY")]) {

--- a/roles/login_ocp/tasks/login.yml
+++ b/roles/login_ocp/tasks/login.yml
@@ -21,4 +21,4 @@
     until: login.rc == 0
     environment:
       KUBECONFIG: "{{ kubeconfig }}"
-    when: (oc_status is defined and oc_status is failed) or force_login|bool
+  when: (oc_status is defined and oc_status is failed) or force_login|bool


### PR DESCRIPTION
This PR enables public NFS services on agnosticd based deployments, provided by the support instance, now destination clusters (OCP4) are also able to access the agnosticd NFS PVs.
 
This eliminates the need of provisioning an additional external NFS server for migrations.

Summary of changes : 
*  Switch branch to agnosticd development (master)
*  Set agnosticd variables to configure NFS public on support instance
* Disable mig-ci external NFS deployment/provisioning only for agnosticd builds (still used by oa/origin3-dev)
* Fix clean/termination logic on agnosticd-base pipeline
* Fix conditional placement on login_ocp role

Sample PV of an already migrated project : 
```
Name:            vol161
Labels:          velero.io/backup-name=nfs-pv-mig-1564026221-xh7k6
                 velero.io/restore-name=nfs-pv-mig-1564026221-j97mb
Annotations:     openshift.io/backup-registry-hostname=docker-registry.default.svc:5000
                 pv.kubernetes.io/bound-by-controller=yes
Finalizers:      [kubernetes.io/pv-protection]
StorageClass:    
Status:          Bound
Claim:           mysql-persistent/mysql
Reclaim Policy:  Recycle
Access Modes:    RWO
VolumeMode:      Filesystem
Capacity:        10Gi
Node Affinity:   <none>
Message:         
Source:
    Type:      NFS (an NFS mount that lasts the lifetime of a pod)
    Server:    support1.jenkins-ci-parallel-base-v3-5.mg.dog8code.com
    Path:      /srv/nfs/user-vols/vol161
    ReadOnly:  false
Events:        <none>
```