### PR TITLE
Ensure custom build mig-controller img is deployed

### DIFF
--- a/pipeline/common_stages.groovy
+++ b/pipeline/common_stages.groovy
@@ -373,6 +373,7 @@ def deploy_mig_controller_on_both(
       // Source
       withEnv([
           "KUBECONFIG=${source_kubeconfig}",
+          "MIG_CONTROLLER_IMG=${QUAYIO_CI_REPO}:${MIG_CONTROLLER_BRANCH}",
           "PATH+EXTRA=~/bin"]) {
         ansiColor('xterm') {
           ansiblePlaybook(
@@ -386,6 +387,7 @@ def deploy_mig_controller_on_both(
       // Target
       withEnv([
           "KUBECONFIG=${target_kubeconfig}",
+          "MIG_CONTROLLER_IMG=${QUAYIO_CI_REPO}:${MIG_CONTROLLER_BRANCH}",
           "PATH+EXTRA=~/bin"]) {
         ansiColor('xterm') {
           ansiblePlaybook(

--- a/roles/mig_controller_deploy/tasks/deploy.yml
+++ b/roles/mig_controller_deploy/tasks/deploy.yml
@@ -1,3 +1,21 @@
+- block:
+  - name: Update with mig controller custom image
+    lineinfile:
+      path: "{{ mig_controller_location }}/config/releases/latest/manifest.yaml"
+      regexp: '^(.*?)image:'
+      line: '\1image: {{ mig_controller_img }}'
+      backrefs: yes
+
+  - name: Update deploy script to use custom image
+    lineinfile:
+      path: "{{ mig_controller_location }}/hack/deploy/deploy_mig.sh"
+      regexp: '^(.*?)manifest.yaml'
+      line: 'oc apply -f {{ mig_controller_location }}/config/releases/latest/manifest.yaml'
+
+  - debug:
+      msg: "Mig controller will be deploy using {{ mig_controller_img }}"
+  when: mig_controller_owner_repo != "https://github.com/fusor/mig-controller.git"
+
 - name: Deploy mig controller and ui
   command: "{{ mig_controller_location }}/hack/deploy/deploy_mig.sh"
   register: deploy

--- a/roles/mig_controller_prereqs/defaults/main.yml
+++ b/roles/mig_controller_prereqs/defaults/main.yml
@@ -3,6 +3,7 @@ cluster_version: "{{ lookup('env', 'CLUSTER_VERSION') or '4' }}"
 mig_controller_location: "{{ workspace }}/mig-controller"
 mig_controller_owner_repo: "{{ lookup('env', 'MIG_CONTROLLER_REPO') or 'https://github.com/fusor/mig-controller.git' }}"
 mig_controller_owner_branch: "{{ lookup('env', 'MIG_CONTROLLER_BRANCH') or 'master' }}"
+mig_controller_img: "{{ lookup('env', 'MIG_CONTROLLER_IMG') or 'quay.io/ocpmigrate/mig-controller:latest' }}"
 mig_controller_namespace: "mig"
 mig_controller_sa_name: "mig"
 mig_controller_host_cluster: true


### PR DESCRIPTION
Pass MIG_CONTROLLER_IMG to mig-controller deployment roles, update deployment manifest and scripts to ensure the custom image is brought up by the MIG statefulset. 