### PR TITLE
Ensure mig-controller sync with operator namespace

### DIFF
--- a/roles/mig_controller_deploy/tasks/check.yml
+++ b/roles/mig_controller_deploy/tasks/check.yml
@@ -1,7 +1,7 @@
 - name: Check velero status
   k8s_facts:
     kind: Pod
-    namespace: "{{ mig_controller_namespace }}"
+    namespace: "{{ mig_operator_namespace }}"
     label_selectors: "component=velero"
   register: pod
   until: "true in (pod | json_query('resources[].status.containerStatuses[].ready'))"
@@ -12,7 +12,7 @@
 - name: Check restic status
   k8s_facts:
     kind: Pod
-    namespace: "{{ mig_controller_namespace }}"
+    namespace: "{{ mig_operator_namespace }}"
     label_selectors: "name=restic"
   register: pod
   until: "true in (pod | json_query('resources[].status.containerStatuses[].ready'))"
@@ -23,7 +23,7 @@
 - name: Check mig controller status
   k8s_facts:
     kind: Pod
-    namespace: "{{ mig_controller_namespace }}"
+    namespace: "{{ mig_operator_namespace }}"
     label_selectors: "control-plane=controller-manager"
   register: pod
   until: "true in (pod | json_query('resources[].status.containerStatuses[].ready'))"

--- a/roles/mig_controller_deploy/tasks/check.yml
+++ b/roles/mig_controller_deploy/tasks/check.yml
@@ -1,7 +1,7 @@
 - name: Check velero status
   k8s_facts:
     kind: Pod
-    namespace: "{{ mig_operator_namespace }}"
+    namespace: "{{ mig_migration_namespace }}"
     label_selectors: "component=velero"
   register: pod
   until: "true in (pod | json_query('resources[].status.containerStatuses[].ready'))"
@@ -12,7 +12,7 @@
 - name: Check restic status
   k8s_facts:
     kind: Pod
-    namespace: "{{ mig_operator_namespace }}"
+    namespace: "{{ mig_migration_namespace }}"
     label_selectors: "name=restic"
   register: pod
   until: "true in (pod | json_query('resources[].status.containerStatuses[].ready'))"

--- a/roles/mig_controller_deploy/tasks/prepare_remote_cluster.yml
+++ b/roles/mig_controller_deploy/tasks/prepare_remote_cluster.yml
@@ -3,7 +3,7 @@
   block:
 
     - name: Extract SA token
-      shell: "{{ oc_binary }} sa get-token -n {{ mig_controller_namespace }} {{ mig_controller_sa_name }} | base64 -w 0"
+      shell: "{{ oc_binary }} sa get-token -n {{ mig_operator_namespace }} {{ mig_controller_sa_name }} | base64 -w 0"
       register: oc_sa_output
 
     - set_fact:

--- a/roles/mig_controller_deploy/templates/controller.yml.j2
+++ b/roles/mig_controller_deploy/templates/controller.yml.j2
@@ -2,7 +2,7 @@ apiVersion: migration.openshift.io/v1alpha1
 kind: MigrationController
 metadata:
   name: migration-controller
-  namespace: mig
+  namespace: {{ mig_operator_namespace }}
 spec:
   cluster_name: host
   migration_velero: {{ mig_controller_velero }}

--- a/roles/mig_controller_destroy/tasks/main.yml
+++ b/roles/mig_controller_destroy/tasks/main.yml
@@ -3,7 +3,15 @@
   include_vars:
     file: "{{ playbook_dir }}/roles/mig_controller_prereqs/defaults/main.yml"
 
-- name: Destroy mig namespace
+- name: Destroy migration namespace
+  k8s:
+    state: absent
+    api_version: v1
+    kind: Namespace
+    name: "{{ mig_migration_namespace }}"
+    wait: yes
+
+- name: Destroy operator namespace
   k8s:
     state: absent
     api_version: v1

--- a/roles/mig_controller_destroy/tasks/main.yml
+++ b/roles/mig_controller_destroy/tasks/main.yml
@@ -1,10 +1,14 @@
 ---
+- name: Include required vars
+  include_vars:
+    file: "{{ playbook_dir }}/roles/mig_controller_prereqs/defaults/main.yml"
+
 - name: Destroy mig namespace
   k8s:
     state: absent
     api_version: v1
     kind: Namespace
-    name: mig
+    name: "{{ mig_operator_namespace }}"
     wait: yes
 
 - name: Destroy velero CRDs

--- a/roles/mig_controller_prereqs/defaults/main.yml
+++ b/roles/mig_controller_prereqs/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+mig_operator_namespace: mig
 mig_operator_location: "{{ workspace }}/mig-operator"
 mig_operator_repo: "{{ lookup('env', 'MIG_OPERATOR_REPO') or 'https://github.com/fusor/mig-operator.git' }}"
 mig_operator_branch: "{{ lookup('env', 'MIG_OPERATOR_BRANCH') or 'master' }}"
@@ -7,7 +8,6 @@ mig_controller_repo: "{{ lookup('env', 'MIG_CONTROLLER_REPO') or 'https://github
 mig_controller_branch: "{{ lookup('env', 'MIG_CONTROLLER_BRANCH') or 'master' }}"
 mig_controller_img: "{{ lookup('env', 'MIG_CONTROLLER_IMG') or 'quay.io/ocpmigrate/mig-controller' }}"
 mig_controller_version: "{{ lookup('env', 'MIG_CONTROLLER_VERSION') or 'latest' }}"
-mig_controller_namespace: mig
 mig_controller_sa_name: mig
 mig_controller_host_cluster: true
 mig_controller_velero: true

--- a/roles/mig_controller_prereqs/defaults/main.yml
+++ b/roles/mig_controller_prereqs/defaults/main.yml
@@ -13,3 +13,4 @@ mig_controller_host_cluster: true
 mig_controller_velero: true
 mig_controller_ui: true
 mig_controller_remote_cluster_online: true
+mig_migration_namespace: mig

--- a/roles/mig_controller_prereqs/tasks/deploy_operator.yml
+++ b/roles/mig_controller_prereqs/tasks/deploy_operator.yml
@@ -13,7 +13,7 @@
 - name: Check status of mig operator
   k8s_facts:
     kind: Pod
-    namespace: "{{ mig_controller_namespace }}"
+    namespace: "{{ mig_operator_namespace }}"
     label_selectors: "app=migration-operator"
   register: pod
   until: "true in (pod | json_query('resources[].status.containerStatuses[].ready'))"


### PR DESCRIPTION
In preparation for the mig-controller/CR namespace split, ensure mig-controller roles can land operator, controller and velero on the correct namespace. (operator)

Once the dependent PRs are merged, we would just need to update "mig" by "openshift-migration-operator".

References : 
https://github.com/fusor/mig-operator/pull/30
https://github.com/fusor/mig-controller/issues/220
