### PR TITLE
Use 'unarchive' instead of 'tar'

### DIFF
--- a/roles/login_ocp/tasks/download_oc_binary.yml
+++ b/roles/login_ocp/tasks/download_oc_binary.yml
@@ -19,7 +19,10 @@
       dest: "{{ oc_arch }}"
 
   - name: "Unpack the binary"
-    command: tar -xzf {{ oc_arch }}  -C {{ oc_arch | dirname }}
+    unarchive:
+      src: "{{ oc_arch }}"
+      dest: "{{ oc_arch | dirname }}"
+      remote_src: yes
 
   - name: Install newly downloaded oc binary
     copy:


### PR DESCRIPTION
https://github.com/fusor/mig-ci/issues/89

Transition 'login_ocp' "Unpack the binary" task from `command` to `unarchive`.