### PR TITLE
Sync controller namespace split in upstream

### DIFF
--- a/roles/mig_controller_prereqs/defaults/main.yml
+++ b/roles/mig_controller_prereqs/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-mig_operator_namespace: mig
+mig_operator_namespace: openshift-migration-operator
 mig_operator_location: "{{ workspace }}/mig-operator"
 mig_operator_repo: "{{ lookup('env', 'MIG_OPERATOR_REPO') or 'https://github.com/fusor/mig-operator.git' }}"
 mig_operator_branch: "{{ lookup('env', 'MIG_OPERATOR_BRANCH') or 'master' }}"
@@ -13,4 +13,4 @@ mig_controller_host_cluster: true
 mig_controller_velero: true
 mig_controller_ui: true
 mig_controller_remote_cluster_online: true
-mig_migration_namespace: mig
+mig_migration_namespace: openshift-migration


### PR DESCRIPTION
- Migration controller now splits into two ns : openshift-migration and
  openshift-migration-operator