### PR TITLE
Replace workspace current dir for playbook_dir

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -1,7 +1,7 @@
 # default common variables for mig-ci roles/plays
 
 # Jenkins WORKSPACE or assume parent dir
-workspace: "{{ lookup('env', 'WORKSPACE') or './'}}"
+workspace: "{{ lookup('env', 'WORKSPACE') or playbook_dir }}"
 # This var is only applicable to mig-controller roles at the moment
 ec2_region: "{{ lookup('env', 'AWS_REGION') or lookup('env', 'EC2_REGION') }}"
 


### PR DESCRIPTION
Use playbook_dir instead of current directory for non-jenkins operation of mig-ci assets. The playbook_dir variable uses an absolute path which is much safer than relative paths for all ansible modules calls
