### PR TITLE
Add e2e playbook param to pipelines

### DIFF
--- a/pipeline/common_stages.groovy
+++ b/pipeline/common_stages.groovy
@@ -420,7 +420,7 @@ def execute_migration(e2e_tests, source_kubeconfig, target_kubeconfig) {
             "PATH+EXTRA=~/bin"]) {
             ansiColor('xterm') {
               ansiblePlaybook(
-                playbook: 'mig_controller_samples.yml',
+                playbook: "${env.E2E_PLAY}",
                 hostKeyChecking: false,
                 extras: "-e 'with_migrate=false'",
                 tags: "${e2e_tests[i]}",
@@ -433,7 +433,7 @@ def execute_migration(e2e_tests, source_kubeconfig, target_kubeconfig) {
             "PATH+EXTRA=~/bin"]) {
             ansiColor('xterm') {
               ansiblePlaybook(
-                playbook: 'mig_controller_samples.yml',
+                playbook: "${env.E2E_PLAY}",
                 hostKeyChecking: false,
                 extras: "-e 'with_deploy=false'",
                 tags: "${e2e_tests[i]}",

--- a/pipeline/mig-e2e-base.groovy
+++ b/pipeline/mig-e2e-base.groovy
@@ -11,6 +11,7 @@ string(defaultValue: 'https://github.com/fusor/mig-controller.git', description:
 string(defaultValue: 'master', description: 'Mig controller repo branch to test', name: 'MIG_CONTROLLER_BRANCH', trim: false),
 string(defaultValue: 'https://github.com/fusor/mig-e2e.git', description: 'Mig e2e repo to test', name: 'MIG_E2E_REPO', trim: false),
 string(defaultValue: 'master', description: 'Mig e2e repo branch to test', name: 'MIG_E2E_BRANCH', trim: false),
+string(defaultValue: 'e2e_mig_samples.yml', description: 'e2e test playbook to run, see https://github.com/fusor/mig-e2e for details', name: 'E2E_PLAY', trim: false),
 string(defaultValue: 'all', description: 'e2e test tags to run, see https://github.com/fusor/mig-e2e for details, space delimited', name: 'E2E_TESTS', trim: false),
 string(defaultValue: 'quay.io/fbladilo/mig-controller', description: 'Repo for quay io mig-controller images', name: 'QUAYIO_CI_REPO', trim: false),
 credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.UsernamePasswordMultiBinding', defaultValue: 'ci_quay_credentials', description: 'Credentials for quay.io container storage, used by mig-controller to push and pull images', name: 'QUAYIO_CREDENTIALS', required: true),
@@ -75,7 +76,7 @@ node {
         utils.notifyBuild(currentBuild.result)
         stage('Clean Up Environment') {
           if (CLEAN_WORKSPACE) {
-              cleanWs cleanWhenFailure: false, notFailBuild: true
+              cleanWs notFailBuild: true
           }
         }
       }

--- a/pipeline/parallel-base.groovy
+++ b/pipeline/parallel-base.groovy
@@ -24,6 +24,7 @@ string(defaultValue: 'https://github.com/fusor/mig-controller.git', description:
 string(defaultValue: 'master', description: 'Mig controller repo branch to test', name: 'MIG_CONTROLLER_BRANCH', trim: false),
 string(defaultValue: 'https://github.com/fusor/mig-e2e.git', description: 'Mig e2e repo to test', name: 'MIG_E2E_REPO', trim: false),
 string(defaultValue: 'master', description: 'Mig e2e repo branch to test', name: 'MIG_E2E_BRANCH', trim: false),
+string(defaultValue: 'e2e_mig_samples.yml', description: 'e2e test playbook to run, see https://github.com/fusor/mig-e2e for details', name: 'E2E_PLAY', trim: false),
 string(defaultValue: 'all', description: 'e2e test tags to run, see https://github.com/fusor/mig-e2e for details, space delimited', name: 'E2E_TESTS', trim: false),
 string(defaultValue: 'quay.io/fbladilo/mig-controller', description: 'Repo for quay io mig-controller images', name: 'QUAYIO_CI_REPO', trim: false),
 credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.UsernamePasswordMultiBinding', defaultValue: 'ci_quay_credentials', description: 'Credentials for quay.io container storage, used by mig-controller to push and pull images', name: 'QUAYIO_CREDENTIALS', required: true),


### PR DESCRIPTION
- Introduce E2E_PLAY param so playbooks can be selected in addition to
  tags
- Clean workspace on failure in mig-e2e-base pipeline, saves diskspace
  on Jenkins and does not affect debugging at clusters