### PR TITLE
Add support to use 'nightly' releases in pipelines

### DIFF
--- a/pipeline/common_stages.groovy
+++ b/pipeline/common_stages.groovy
@@ -132,7 +132,7 @@ def deploy_ocp3_agnosticd(kubeconfig) {
           writeYaml file: 'vars.yml', data: vars
           vars = vars.collect { e -> '-e ' + e.key + '=' + e.value }
 
-          // Dump teardown wars on host
+          // Dump teardown vars on host
           def teardown_vars = [
             'aws_region': "${AWS_REGION}",
             'guid': "${CLUSTER_NAME}-v3-${BUILD_NUMBER}",
@@ -185,17 +185,26 @@ def deploy_ocp3_agnosticd(kubeconfig) {
 }
 
 def deployOCP4(kubeconfig) {
+  def release_version = "${OCP4_VERSION.substring(1)}"
+  def releases = [
+    '4.1': "4.1.13",
+    '4.2': "nightly",
+    'ightly': "nightly"
+  ]
+  def osrelease = releases["${release_version}"]
+
+
   sh "echo './openshift-install destroy cluster &' >> destroy_env.sh"
   return {
     stage('Deploy OCP4 cluster') {
-      steps_finished << 'Deploy OCP4 ' + OCP4_VERSION
+      steps_finished << 'Deploy OCP4 ' + OCP4_VERSION + " (" + osrelease + ")"
       withCredentials([
           string(credentialsId: "$EC2_ACCESS_KEY_ID", variable: 'AWS_ACCESS_KEY_ID'),
           string(credentialsId: "$EC2_SECRET_ACCESS_KEY", variable: 'AWS_SECRET_ACCESS_KEY'),
           [$class: 'UsernamePasswordMultiBinding', credentialsId: "${OCP4_CREDENTIALS}", usernameVariable: 'OCP4_ADMIN_USER', passwordVariable: 'OCP4_ADMIN_PASSWD']
           ])
       {
-        withEnv(["KUBECONFIG=${kubeconfig}", "CLUSTER_NAME=${CLUSTER_NAME}-v4-${BUILD_NUMBER}"]){
+        withEnv(["KUBECONFIG=${kubeconfig}", "CLUSTER_NAME=${CLUSTER_NAME}-v4-${BUILD_NUMBER}", "OCP4_RELEASE=${osrelease}"]){
           ansiColor('xterm') {
             ansiblePlaybook(
               playbook: 'deploy_ocp4_cluster.yml',

--- a/roles/ocp4_cluster_deploy/defaults/main.yml
+++ b/roles/ocp4_cluster_deploy/defaults/main.yml
@@ -1,6 +1,7 @@
-openshift_installer_release: "4.1.12"
+openshift_installer_release: "{{ lookup('env', 'OCP4_RELEASE') or '4.1.13' }}"
 openshift_installer_release_type: "linux"
 openshift_installer_release_url: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{ openshift_installer_release }}/openshift-install-{{ openshift_installer_release_type }}-{{ openshift_installer_release }}.tar.gz"
 ocp4_admin_user:  "{{ lookup('env', 'OCP4_ADMIN_USER') or 'admin' }}"
 ocp4_admin_password:  "{{ lookup('env', 'OCP4_ADMIN_PASSWD') or 'r3dh4t1!' }}"
 ocp4_htpasswd_file: "{{ playbook_dir }}/ocp4-htpasswd"
+openshift_installer_nightly_release_url_prefix: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview/"

--- a/roles/ocp4_cluster_deploy/tasks/get_ocp4_installer.yml
+++ b/roles/ocp4_cluster_deploy/tasks/get_ocp4_installer.yml
@@ -1,5 +1,9 @@
 ---
-- name: get installer
+- name: Get nightly
+  include_tasks: get_ocp4_nightly.yml
+  when: openshift_installer_release == "nightly"
+
+- name: Get installer
   unarchive:
     src: "{{ openshift_installer_release_url }}"
     dest: "{{ playbook_dir }}"

--- a/roles/ocp4_cluster_deploy/tasks/get_ocp4_nightly.yml
+++ b/roles/ocp4_cluster_deploy/tasks/get_ocp4_nightly.yml
@@ -1,0 +1,16 @@
+---
+- name: "Discover latest nightly installer release"
+  shell: wget -O - {{ openshift_installer_nightly_release_url_prefix }} 2>/dev/null \
+         | grep -i nightly \
+         | cut -d\> -f6 \
+         | sed -e 's|<a href=||g' -e 's|</a||g' -e 's|"||g' -e 's|/||g' \
+         | sort -u \
+         | tail -n1
+  args:
+    warn: no
+  register: latest_nightly
+
+- name: "Set variables to {{ latest_nightly.stdout }} release"
+  set_fact:
+    openshift_installer_release: "{{ latest_nightly.stdout }}"
+    openshift_installer_release_url: "{{ openshift_installer_nightly_release_url_prefix }}/{{ latest_nightly.stdout }}/openshift-install-{{ openshift_installer_release_type }}-{{ latest_nightly.stdout }}.tar.gz"


### PR DESCRIPTION
`roles/ocp4_cluster_deploy/tasks/get_ocp4_nightly.yml`:
* Discover latest nightly release
* Set variables accordingly
---
`roles/ocp4_cluster_deploy/tasks/get_ocp4_installer.yml`:
* Add task to include `get_ocp4_nightly.yml` when `openshift_installer_release == "nightly"`
---
`roles/ocp4_cluster_deploy/defaults/main.yml`:
* Add lookup for `openshift_installer_release`
* Update `openshift_installer_release` default value to *4.1.13*
---
`pipeline/common_stages.groovy`:
* Add variables to support version/release selection