### PR TITLE
Ensure s3 bucket is unique within a region

### DIFF
--- a/pipeline/mig-e2e-base.groovy
+++ b/pipeline/mig-e2e-base.groovy
@@ -82,6 +82,8 @@ node {
         // Success or failure, always send notifications
         utils.notifyBuild(currentBuild.result)
         stage('Clean Up Environment') {
+          // Always attempt to remove s3 buckets
+          utils.teardown_s3_bucket()
           if (CLEAN_WORKSPACE) {
               cleanWs notFailBuild: true
           }

--- a/pipeline/parallel-base.groovy
+++ b/pipeline/parallel-base.groovy
@@ -157,6 +157,8 @@ node {
                             }
                         }
                 }
+            // Always attempt to remove s3 buckets
+            utils.teardown_s3_bucket()
             if (CLEAN_WORKSPACE) {
                 utils.teardown_container_image()
                 cleanWs cleanWhenFailure: false, notFailBuild: true

--- a/pipeline/utils.groovy
+++ b/pipeline/utils.groovy
@@ -283,5 +283,19 @@ def teardown_container_image() {
   }
 }
 
+def teardown_s3_bucket() {
+  withCredentials([
+    string(credentialsId: "$EC2_ACCESS_KEY_ID", variable: 'AWS_ACCESS_KEY_ID'),
+    string(credentialsId: "$EC2_SECRET_ACCESS_KEY", variable: 'AWS_SECRET_ACCESS_KEY')
+    ]) {
+    ansiColor('xterm') {
+      ansiblePlaybook(
+        playbook: 's3_bucket_destroy.yml',
+        hostKeyChecking: false,
+        unbuffered: true,
+        colorized: true)
+    }
+  }
+}
 
 return this

--- a/roles/mig_controller_destroy/tasks/destroy_s3_bucket.yml
+++ b/roles/mig_controller_destroy/tasks/destroy_s3_bucket.yml
@@ -1,0 +1,37 @@
+- name: Check that velero_aws_credentials were created
+  stat:
+    path: "{{ playbook_dir }}/config/velero_aws_creds.yml"
+  register: creds
+
+- name: Destroy S3 bucket if present
+  block:
+
+    - name: Get bucket info
+      include_vars:
+        file: "{{ playbook_dir }}/config/velero_aws_creds.yml"
+
+    - name: Get AWS account information
+      aws_caller_facts:
+      register: caller_facts
+
+    - name: Retrieve AWS account identifier (ARN) for use in resource tags
+      set_fact:
+        aws_account_arn: "{{ caller_facts.arn }}"
+
+    - debug:
+        msg: "Will destroy s3 bucket : {{ velero_aws_bucket_name }}"
+
+    - name: Delete S3 bucket for backup storage of OpenShift resource definitions
+      s3_bucket:
+        state: absent
+        force: true
+        name: "{{ velero_aws_bucket_name }}"
+        region: "{{ ec2_region }}"
+        tags:
+          owner: "{{ aws_account_arn }}"
+
+    - name: Remove old aws backup storage access keys
+      file:
+        path: "{{ playbook_dir }}/config/velero_aws_creds.yml"
+        state: absent
+  when: creds.stat.exists

--- a/roles/mig_controller_prereqs/tasks/create_aws_backup_storage.yml
+++ b/roles/mig_controller_prereqs/tasks/create_aws_backup_storage.yml
@@ -10,14 +10,20 @@
       aws_caller_facts:
       register: caller_facts
 
+    - set_fact:
+        random: "{{ 100000 | random }}"
+
+    # Add randomization to arn_and_region to ensure uniquess within a region
     - name: Retrieve AWS account identifier (ARN) for use in resource tags
       set_fact:
         aws_account_arn: "{{ caller_facts.arn }}"
-        arn_and_region: "{{ caller_facts.arn }}-{{ ec2_region }}"
+        arn_and_region: "{{ caller_facts.arn }}-{{ ec2_region }}-{{ random }}"
 
-    # Set this separately to explicitly mention we are setting md5 hash to include uniqueness across regions
     - set_fact:
-        aws_resource_name: "velero-{{ arn_and_region | hash('md5') }}"
+        aws_resource_name: "velero-ci-{{ arn_and_region | hash('md5') }}"
+
+    - debug:
+        msg: "Will create s3 bucket : {{ aws_resource_name }}"
 
     - name: Create S3 bucket for backup storage of OpenShift resource definitions
       s3_bucket:

--- a/roles/mig_controller_prereqs/templates/velero_aws_creds.yml.j2
+++ b/roles/mig_controller_prereqs/templates/velero_aws_creds.yml.j2
@@ -1,3 +1,4 @@
 velero_aws_access_key: {{ velero_aws_access_key }}
 velero_aws_secret_key: {{ velero_aws_secret_key }}
 velero_aws_bucket_name: {{ aws_resource_name }}
+velero_aws_bucket_region: {{ ec2_region }}

--- a/s3_bucket_destroy.yml
+++ b/s3_bucket_destroy.yml
@@ -1,7 +1,7 @@
 - hosts: localhost
   tasks:
     - include_role:
-        name: mig_tools_setup
+        name: mig_controller_destroy
         tasks_from: destroy_s3_bucket.yml
   vars_files:
     - "{{ playbook_dir }}/config/defaults.yml"

--- a/setup_velero.yml
+++ b/setup_velero.yml
@@ -1,6 +1,0 @@
-- hosts: localhost
-  roles:
-  - mig_tools_prereqs
-  - role: mig_tools_setup
-  vars_files:
-    - "{{ playbook_dir }}/config/defaults.yml"


### PR DESCRIPTION
This PR eliminates an issue when multiple cluster pairs on the same AWS region will step into each others credentials.

* Each s3 bucket is now unique when controllers are deployed
* mig_controller_prereqs will handle the generation of velero_aws_creds.yml , the block only runs if the file is not present already
* mig_controller_destroy will check the existance of velero_aws_creds.yml and proceed to execute a block to destroy the s3 bucket and the creds file
* AWS bucket region is now also included in velero_aws_creds.yml
* mig_tools_setup.yml was removed as part of cleanup