### PR TITLE
Allow setting of MIG operator repo/branch

### DIFF
--- a/pipeline/mig-e2e-base.groovy
+++ b/pipeline/mig-e2e-base.groovy
@@ -7,6 +7,8 @@ string(defaultValue: 'v4.1', description: 'OCP4 version to test', name: 'OCP4_VE
 string(defaultValue: '', description: 'OCP3 source cluster API endpoint', name: 'OCP3_CLUSTER_URL', trim: false, required: true),
 string(defaultValue: '', description: 'OCP4 destination cluster API endpoint', name: 'OCP4_CLUSTER_URL', trim: false, required: true),
 string(defaultValue: '', description: 'AWS region where clusters are deployed', name: 'AWS_REGION', trim: false, required: true),
+string(defaultValue: 'https://github.com/fusor/mig-operator.git', description: 'Mig operator repo to clone', name: 'MIG_OPERATOR_REPO', trim: false),
+string(defaultValue: 'master', description: 'Mig operator branch to test', name: 'MIG_OPERATOR_BRANCH', trim: false),
 string(defaultValue: 'https://github.com/fusor/mig-controller.git', description: 'Mig controller repo to test, only used by GHPRB', name: 'MIG_CONTROLLER_REPO', trim: false),
 string(defaultValue: 'master', description: 'Mig controller repo branch to test', name: 'MIG_CONTROLLER_BRANCH', trim: false),
 string(defaultValue: 'https://github.com/fusor/mig-e2e.git', description: 'Mig e2e repo to test', name: 'MIG_E2E_REPO', trim: false),

--- a/pipeline/parallel-base.groovy
+++ b/pipeline/parallel-base.groovy
@@ -22,6 +22,8 @@ string(defaultValue: 'ocp-workshop', description: 'AgnosticD environment type to
 string(defaultValue: 'ci', description: 'EC2 SSH key name to deploy on instances for remote access ', name: 'EC2_KEY', trim: false),
 string(defaultValue: 'us-west-1', description: 'AWS region to deploy instances', name: 'AWS_REGION', trim: false),
 string(defaultValue: 'agnosticd', description: 'Deployment type to choose', name: 'DEPLOYMENT_TYPE', trim: false),
+string(defaultValue: 'https://github.com/fusor/mig-operator.git', description: 'Mig operator repo to clone', name: 'MIG_OPERATOR_REPO', trim: false),
+string(defaultValue: 'master', description: 'Mig operator branch to test', name: 'MIG_OPERATOR_BRANCH', trim: false),
 string(defaultValue: 'https://github.com/fusor/mig-controller.git', description: 'Mig controller repo to test, only used by GHPRB', name: 'MIG_CONTROLLER_REPO', trim: false),
 string(defaultValue: 'master', description: 'Mig controller repo branch to test', name: 'MIG_CONTROLLER_BRANCH', trim: false),
 string(defaultValue: 'https://github.com/fusor/mig-e2e.git', description: 'Mig e2e repo to test', name: 'MIG_E2E_REPO', trim: false),


### PR DESCRIPTION
- Allows to pick which operator branch we clone, defaults to master
- The cloning of operator is used by mig_controller_prereqs to launch
  operator
- Tags of operator are still set by MIG_OPERATOR_TAG