### PR TITLE
Destroy cluster role bindings via mig_controller_destroy

### DIFF
--- a/roles/mig_controller_destroy/defaults/main.yml
+++ b/roles/mig_controller_destroy/defaults/main.yml
@@ -12,3 +12,7 @@ velero_crds:
   - schedules.velero.io
   - serverstatusrequests.velero.io
   - volumesnapshotlocations.velero.io
+mig_cluster_role_bindings:
+  - migration-operator
+  - velero
+  - mig-cluster-admin

--- a/roles/mig_controller_destroy/tasks/main.yml
+++ b/roles/mig_controller_destroy/tasks/main.yml
@@ -20,3 +20,12 @@
     name: "{{ item }}"
     wait: yes
   with_items: "{{ velero_crds }}"
+
+- name: Destroy cluster role bindings
+  k8s:
+    state: absent
+    api_version: rbac.authorization.k8s.io/v1beta1
+    kind: ClusterRoleBinding
+    name: "{{ item }}"
+    wait: yes
+  with_items: "{{ mig_cluster_role_bindings }}"

--- a/roles/mig_controller_destroy/tasks/main.yml
+++ b/roles/mig_controller_destroy/tasks/main.yml
@@ -29,3 +29,6 @@
     name: "{{ item }}"
     wait: yes
   with_items: "{{ mig_cluster_role_bindings }}"
+
+- name: Destroy s3 bucket if present
+  include: destroy_s3_bucket.yml

--- a/roles/mig_controller_prereqs/tasks/deploy_operator.yml
+++ b/roles/mig_controller_prereqs/tasks/deploy_operator.yml
@@ -1,9 +1,15 @@
+- name: Check if mig operator repo exists
+  stat:
+    path: "{{ mig_operator_location }}"
+  register: op_repo
+
 - name: Clone the mig operator repo
   git:
     dest: "{{ mig_operator_location }}"
     repo: "{{ mig_operator_repo }}"
     version: "{{ mig_operator_branch }}"
   ignore_errors: true
+  when: not op_repo.stat.exists
 
 - name: Update operator to use {{ mig_operator_tag }} tag
   replace:


### PR DESCRIPTION
This PR does a few maintenance tasks : 
* Destroys any remaining cluster role bindings via mig_controller_destroy
* Prevents operator repo from attempting to clone if it is already present
* Cleans up s3 buckets via mig_controller_destroy even when run outside Jenkins CI