### PR TITLE
Add debugging to e2e pipelines

### DIFF
--- a/pipeline/mig-e2e-base.groovy
+++ b/pipeline/mig-e2e-base.groovy
@@ -28,7 +28,7 @@ credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.StringC
 credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl', defaultValue: 'ci_aws_secret_access_key', description: 'EC2 private key needed to access instances, from Jenkins credentials store', name: 'EC2_SECRET_ACCESS_KEY', required: true),
 credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.UsernamePasswordMultiBinding', defaultValue: 'ci_ocp4_admin_credentials', description: 'Cluster admin credentials used in OCP4 deployments', name: 'OCP4_CREDENTIALS', required: true),
 credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.UsernamePasswordMultiBinding', defaultValue: 'ci_ocp3_admin_credentials', description: 'Cluster admin credentials used in OCP3 deployments', name: 'OCP3_CREDENTIALS', required: true),
-booleanParam(defaultValue: true, description: 'Enable debugging', name: 'DEBUG'),
+booleanParam(defaultValue: false, description: 'Enable debugging', name: 'DEBUG'),
 booleanParam(defaultValue: true, description: 'Clean up workspace after build', name: 'CLEAN_WORKSPACE')])])
 
 // true/false build parameter that defines if we cleanup workspace once build is done

--- a/pipeline/parallel-base.groovy
+++ b/pipeline/parallel-base.groovy
@@ -166,7 +166,7 @@ node {
             utils.teardown_s3_bucket()
             if (CLEAN_WORKSPACE) {
                 utils.teardown_container_image()
-                cleanWs cleanWhenFailure: false, notFailBuild: true
+                cleanWs notFailBuild: true
             }
         }
     }

--- a/pipeline/parallel-base.groovy
+++ b/pipeline/parallel-base.groovy
@@ -61,6 +61,8 @@ def CLEAN_WORKSPACE = params.CLEAN_WORKSPACE
 def E2E_RUN = params.E2E_RUN
 // Split e2e tests from string param
 def E2E_TESTS = params.E2E_TESTS.split(' ')
+// true/false enable debugging
+def DEBUG = params.DEBUG
 
 def common_stages
 def utils

--- a/pipeline/parallel-base.groovy
+++ b/pipeline/parallel-base.groovy
@@ -135,6 +135,11 @@ node {
     } finally {
         // Success or failure, always send notifications
         utils.notifyBuild(currentBuild.result)
+        if (DEBUG) {
+          utils.run_debug(SOURCE_KUBECONFIG)
+          utils.run_debug(TARGET_KUBECONFIG)
+	}
+
         stage('Clean Up Environment') {
             // Always attempt to terminate instances if EC2_TERMINATE_INSTANCES is true
             if (EC2_TERMINATE_INSTANCES) {
@@ -162,6 +167,7 @@ node {
                             }
                         }
                 }
+
             // Always attempt to remove s3 buckets
             utils.teardown_s3_bucket()
             if (CLEAN_WORKSPACE) {

--- a/pipeline/parallel-base.groovy
+++ b/pipeline/parallel-base.groovy
@@ -35,6 +35,8 @@ string(defaultValue: 'latest', description: 'Mig controller version/tag to deplo
 string(defaultValue: 'latest', description: 'Mig ui version/tag to deploy', name: 'MIG_UI_TAG', trim: false),
 string(defaultValue: 'latest', description: 'Mig velero version/tag to deploy', name: 'MIG_VELERO_TAG', trim: false),
 string(defaultValue: 'latest', description: 'Mig velero plugin version/tag to deploy', name: 'MIG_VELERO_PLUGIN_TAG', trim: false),
+string(defaultValue: 'scripts/mig_debug.sh', description: 'Relative file path to debug script on MIG CI repo', name: 'DEBUG_SCRIPT', trim: false),
+string(defaultValue: '', description: 'Extra debug script arguments', name: 'DEBUG_SCRIPT_ARGS', trim: false),
 string(defaultValue: 'quay.io/fbladilo/mig-controller', description: 'Repo for quay io for custom mig-controller images, only used by GHPRB', name: 'QUAYIO_CI_REPO', trim: false),
 credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.UsernamePasswordMultiBinding', defaultValue: 'ci_quay_credentials', description: 'Credentials for quay.io container storage, used by mig-controller to push and pull images', name: 'QUAYIO_CREDENTIALS', required: true),
 credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl', defaultValue: 'agnosticd_own_repo', description: 'Private repo address for openshift-ansible packages', name: 'AGND_REPO', required: true),
@@ -48,6 +50,7 @@ credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.FileCre
 credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.UsernamePasswordMultiBinding', defaultValue: 'ci_ocp4_admin_credentials', description: 'Cluster admin credentials used in OCP4 deployments', name: 'OCP4_CREDENTIALS', required: true),
 booleanParam(defaultValue: true, description: 'Run e2e tests', name: 'E2E_RUN'),
 booleanParam(defaultValue: true, description: 'Clean up workspace after build', name: 'CLEAN_WORKSPACE'),
+booleanParam(defaultValue: false, description: 'Enable debugging', name: 'DEBUG'),
 booleanParam(defaultValue: true, description: 'EC2 terminate instances after build', name: 'EC2_TERMINATE_INSTANCES')])])
 
 // true/false build parameter that defines if we terminate instances once build is done

--- a/pipeline/utils.groovy
+++ b/pipeline/utils.groovy
@@ -298,4 +298,10 @@ def teardown_s3_bucket() {
   }
 }
 
+def run_debug(kubeconfig) {
+  withEnv([ "KUBECONFIG=${kubeconfig}" ]) {
+    sh "${DEBUG_SCRIPT} ${DEBUG_SCRIPT_ARGS}"
+  }
+}
+
 return this

--- a/scripts/mig_debug.sh
+++ b/scripts/mig_debug.sh
@@ -56,12 +56,12 @@ else
 fi
 
 echo
-echo "##### Print OC client env #####"
+echo "##### Print OCP client env #####"
 echo
 ${OC_BINARY} version
 echo 
 
-oc_url=$(${OC_BINARY} whoami --show-server)
+oc_url=$( ${OC_BINARY} whoami --show-server )
 
 echo
 echo "##### Print all resources on ${MIG_NS} namespace #####"
@@ -69,16 +69,22 @@ echo
 oc -n ${MIG_NS} get all
 echo
 
+echo
+echo "##### Dump all images on ${MIG_NS} namespace #####"
+echo
+oc -n ${MIG_NS} describe pods | grep -B3 "Image ID:"
+echo
+
 # Check if cluster hosting controller
 
 mig_controller_check=$( ${OC_BINARY} -n ${MIG_NS} get pods | grep controller-manager )
 if [ $? -ne 0 ]; then
 	echo
-	echo "Controller pod not found, skipping mig CRs..."
+	echo "Controller pod not found, skipping mig CR extraction..."
 	echo
 else
 	WITH_CONTROLLER="true"
-	echo "Controller pod found : "
+	echo "Controller pod found, begin CRs extraction : "
 	echo
 	echo "====== Extract migmigrations ======"
 	echo
@@ -152,6 +158,7 @@ for pod in ${mig_bad_pods[@]}; do
 	echo
 	echo "====== ${MIG_NS} extract logs for not running pods ======"
 	echo
+	echo "Processing pod : ${pod}"
 	${OC_BINARY} -n ${MIG_NS} logs ${pod}
 done
 

--- a/scripts/mig_debug.sh
+++ b/scripts/mig_debug.sh
@@ -61,8 +61,6 @@ echo
 ${OC_BINARY} version
 echo 
 
-oc_url=$( ${OC_BINARY} whoami --show-server )
-
 echo
 echo "##### Print all resources on ${MIG_NS} namespace #####"
 echo

--- a/scripts/mig_debug.sh
+++ b/scripts/mig_debug.sh
@@ -11,8 +11,8 @@ DATE=`date`
 echo "############################## BEGIN MIG DEBUG ##################################"
 echo -e "\t\t\t$DATE"
 echo "#################################################################################"
-
-echo -n "Check status of oc session "
+echo
+echo -n "Check status of oc session : "
 oc_status=$( ${OC_BINARY} whoami )
 
 if [ $? -ne 0 ]; then
@@ -25,6 +25,7 @@ fi
 
 echo
 echo "##### Print OC client env #####"
+echo
 ${OC_BINARY} version
 echo 
 
@@ -45,7 +46,7 @@ if [ $? -ne 0 ]; then
 	echo
 else
 	WITH_CONTROLLER="true"
-	echo "Controller pod running : ${mig_controller_pod}"
+	echo "Controller pod found : "
 	echo
 	echo "====== Extract migmigrations ======"
 	echo
@@ -78,7 +79,7 @@ velero_pod=$( ${OC_BINARY} -n ${MIG_NS} get pods | grep velero | cut -d " " -f1 
 
 if [ ${WITH_CONTROLLER} == "true" ]; then
 	echo "=== Mig controller logs ==="
-#	${OC_BINARY} -n ${MIG_NS} logs ${mig_controller_pod}
+	${OC_BINARY} -n ${MIG_NS} logs ${mig_controller_pod}
 fi
 
 echo
@@ -121,7 +122,7 @@ for ns in ${E2E_NS}; do
 	echo
 	echo "====== $ns check pods not in running state ======"
 	echo
-	readarray -t bad_pods <<< $(${OC_BINARY} -n ${ns} get pods --no-headers --field-selector=status.phase!=Running | cut -d " " -f1)
+	readarray -t bad_pods <<< $(${OC_BINARY} -n ${ns} get pods --no-headers --field-selector=status.phase!=Running,status.phase!=Succeeded | cut -d " " -f1)
 	if [ ${#bad_pods[@]} -ne 0 ]; then
 		echo
 		echo "====== $ns extract logs for not running pods ======"

--- a/scripts/mig_debug.sh
+++ b/scripts/mig_debug.sh
@@ -1,12 +1,44 @@
 #!/bin/bash
-# Mig operator logs disabled by default, they are very large
+# Mig operator and velero logs disabled by default (they are very large), enable via script args as needed
 
 OC_BINARY=`which oc`
 MIG_NS="openshift-migration"
 WITH_CONTROLLER="false"
 WITH_OPERATOR_LOGS=${WITH_OPERATOR_LOGS:-false}
+WITH_VELERO_LOGS=${WITH_VELERO_LOGS:-false}
 E2E_NS=${E2E_NS:-"sock-shop robot-shop parks-app mysql-persistent"}
 DATE=`date`
+
+# Process arguments if passed, assume defaults otherwise
+
+function usage () {
+echo
+echo "Valid options are : "
+echo -e "\t-w : Enable velero logs"
+echo -e "\t-o : Enable operator logs"
+echo
+echo "Will continue with defaults..."
+echo
+}
+
+while getopts :woh opt
+do
+    case $opt in
+        w)
+            WITH_VELERO_LOGS=true
+            ;;
+        o)
+            WITH_OPERATOR_LOGS=true
+            ;;
+        h)
+            usage
+            ;;
+        *)
+            echo "Invalid option: -$OPTARG" >&2
+            usage
+            ;;
+    esac
+done
 
 echo "############################## BEGIN MIG DEBUG ##################################"
 echo -e "\t\t\t$DATE"
@@ -82,18 +114,21 @@ if [ ${WITH_CONTROLLER} == "true" ]; then
 	${OC_BINARY} -n ${MIG_NS} logs ${mig_controller_pod}
 fi
 
-echo
-echo "====== Velero logs ======"
-echo
-${OC_BINARY} -n ${MIG_NS} logs ${velero_pod}
+if [ ${WITH_VELERO_LOGS} == "true" ]; then
+	echo
+	echo "====== Velero logs ======"
+	echo
+	${OC_BINARY} -n ${MIG_NS} logs ${velero_pod}
+	echo
+fi
 
 if [ ${WITH_OPERATOR_LOGS} == "true" ]; then
-echo
-echo "====== Operator logs ======"
-echo
-${OC_BINARY} -n ${MIG_NS} logs ${operator_pod} -c ansible
-${OC_BINARY} -n ${MIG_NS} logs ${operator_pod} -c operator
-echo
+	echo
+	echo "====== Operator logs ======"
+	echo
+	${OC_BINARY} -n ${MIG_NS} logs ${operator_pod} -c ansible
+	${OC_BINARY} -n ${MIG_NS} logs ${operator_pod} -c operator
+	echo
 fi
 
 # Restic DS spawns multiple pods , collect them first
@@ -106,10 +141,24 @@ for pod in ${restic_pods[@]}; do
 	echo
 	${OC_BINARY} -n ${MIG_NS} logs ${pod}
 done
+
+# Scan openshift-migration for not running pods
+declare -a mig_bad_pods
+echo
+echo "====== ${MIG_NS} check pods not in running state ======"
+echo
+readarray -t mig_bad_pods <<< $(${OC_BINARY} -n ${MIG_NS} get pods --no-headers --field-selector=status.phase!=Running,status.phase!=Succeeded | cut -d " " -f1)
+for pod in ${mig_bad_pods[@]}; do
+	echo
+	echo "====== ${MIG_NS} extract logs for not running pods ======"
+	echo
+	${OC_BINARY} -n ${MIG_NS} logs ${pod}
+done
+
 echo
 echo "##### Process E2E namespaces #####"
 echo
-declare -a bad_pods
+declare -a e2e_bad_pods
 for ns in ${E2E_NS}; do
 	echo
 	echo "====== $ns all ======"
@@ -122,15 +171,15 @@ for ns in ${E2E_NS}; do
 	echo
 	echo "====== $ns check pods not in running state ======"
 	echo
-	readarray -t bad_pods <<< $(${OC_BINARY} -n ${ns} get pods --no-headers --field-selector=status.phase!=Running,status.phase!=Succeeded | cut -d " " -f1)
-	if [ ${#bad_pods[@]} -ne 0 ]; then
+	readarray -t e2e_bad_pods <<< $(${OC_BINARY} -n ${ns} get pods --no-headers --field-selector=status.phase!=Running,status.phase!=Succeeded | cut -d " " -f1)
+	if [ ${#e2e_bad_pods[@]} -ne 0 ]; then
 		echo
 		echo "====== $ns extract logs for not running pods ======"
 		echo
-		for bad_pod in ${bad_pods[@]}; do
-			echo "Processing pod : ${bad_pod}"
-			${OC_BINARY} -n $ns logs ${bad_pod}
+		for pod in ${e2e_bad_pods[@]}; do
+			echo "Processing pod : ${pod}"
+			${OC_BINARY} -n $ns logs ${pod}
 		done
 	fi
-	unset bad_pods
+	unset e2e_bad_pods
 done

--- a/scripts/mig_debug.sh
+++ b/scripts/mig_debug.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+# Mig operator logs disabled by default, they are very large
+
+OC_BINARY=`which oc`
+MIG_NS="openshift-migration"
+WITH_CONTROLLER="false"
+WITH_OPERATOR_LOGS=${WITH_OPERATOR_LOGS:-false}
+E2E_NS=${E2E_NS:-"sock-shop robot-shop parks-app mysql-persistent"}
+DATE=`date`
+
+echo "############################## BEGIN MIG DEBUG ##################################"
+echo -e "\t\t\t$DATE"
+echo "#################################################################################"
+
+echo -n "Check status of oc session "
+oc_status=$( ${OC_BINARY} whoami )
+
+if [ $? -ne 0 ]; then
+	echo "FAILED"
+	echo "oc session does not seem to be valid, exiting..."
+        exit 1
+else
+	echo "OK"
+fi
+
+echo
+echo "##### Print OC client env #####"
+${OC_BINARY} version
+echo 
+
+oc_url=$(${OC_BINARY} whoami --show-server)
+
+echo
+echo "##### Print all resources on ${MIG_NS} namespace #####"
+echo
+oc -n ${MIG_NS} get all
+echo
+
+# Check if cluster hosting controller
+
+mig_controller_check=$( ${OC_BINARY} -n ${MIG_NS} get pods | grep controller-manager )
+if [ $? -ne 0 ]; then
+	echo
+	echo "Controller pod not found, skipping mig CRs..."
+	echo
+else
+	WITH_CONTROLLER="true"
+	echo "Controller pod running : ${mig_controller_pod}"
+	echo
+	echo "====== Extract migmigrations ======"
+	echo
+	${OC_BINARY} -n ${MIG_NS} describe migmigration
+	echo
+	echo "====== Extract migplans ======"
+	echo
+	${OC_BINARY} -n ${MIG_NS} describe migplan
+	echo
+	echo "====== Extract migstorage ======"
+	echo
+	${OC_BINARY} -n ${MIG_NS} describe migstorage
+	echo
+	echo "====== Extract migclusters ======"
+	echo
+        ${OC_BINARY} -n ${MIG_NS} describe migcluster
+	echo
+	echo "====== Extract clusters ======"
+	echo
+        ${OC_BINARY} -n ${MIG_NS} describe cluster
+	echo
+fi
+
+# Collect logs
+echo "##### Process LOGS #####"
+echo
+mig_controller_pod=$( ${OC_BINARY} -n ${MIG_NS} get pods | grep controller-manager | cut -d " " -f1 )
+operator_pod=$( ${OC_BINARY} -n ${MIG_NS} get pods | grep migration-operator | cut -d " " -f1 )
+velero_pod=$( ${OC_BINARY} -n ${MIG_NS} get pods | grep velero | cut -d " " -f1 )
+
+if [ ${WITH_CONTROLLER} == "true" ]; then
+	echo "=== Mig controller logs ==="
+#	${OC_BINARY} -n ${MIG_NS} logs ${mig_controller_pod}
+fi
+
+echo
+echo "====== Velero logs ======"
+echo
+${OC_BINARY} -n ${MIG_NS} logs ${velero_pod}
+
+if [ ${WITH_OPERATOR_LOGS} == "true" ]; then
+echo
+echo "====== Operator logs ======"
+echo
+${OC_BINARY} -n ${MIG_NS} logs ${operator_pod} -c ansible
+${OC_BINARY} -n ${MIG_NS} logs ${operator_pod} -c operator
+echo
+fi
+
+# Restic DS spawns multiple pods , collect them first
+declare -a restic_pods                                                                                                                                                                                             
+readarray -t restic_pods <<< $(oc -n openshift-migration get pods | grep restic | cut -d " " -f1)
+
+for pod in ${restic_pods[@]}; do
+	echo
+	echo "====== Restic logs ======"
+	echo
+	${OC_BINARY} -n ${MIG_NS} logs ${pod}
+done
+echo
+echo "##### Process E2E namespaces #####"
+echo
+declare -a bad_pods
+for ns in ${E2E_NS}; do
+	echo
+	echo "====== $ns all ======"
+	echo
+	${OC_BINARY} -n ${ns} get all
+	echo
+	echo "====== $ns pvc ======"
+	echo
+	${OC_BINARY} -n ${ns} get pvc
+	echo
+	echo "====== $ns check pods not in running state ======"
+	echo
+	readarray -t bad_pods <<< $(${OC_BINARY} -n ${ns} get pods --no-headers --field-selector=status.phase!=Running | cut -d " " -f1)
+	if [ ${#bad_pods[@]} -ne 0 ]; then
+		echo
+		echo "====== $ns extract logs for not running pods ======"
+		echo
+		for bad_pod in ${bad_pods[@]}; do
+			echo "Processing pod : ${bad_pod}"
+			${OC_BINARY} -n $ns logs ${bad_pod}
+		done
+	fi
+	unset bad_pods
+done


### PR DESCRIPTION
Add debugging tasks at the end of each e2e pipeline run : 

* parallel-base and mig-e2e-base will execute debugging when enabled
* debug script will perform essential debugging tasks on both clusters
* output of mig-debug script can be used to share and include on any issues reported
* mig-debug script can take arguments to enable operator and velero log processing, they are disabled by default since they tend to be large.
* workspace cleanup on parallel-base has been set to remove even on failure