### PR TITLE
Always destroy cluster manager role in cleanup

### DIFF
--- a/roles/mig_controller_destroy/tasks/main.yml
+++ b/roles/mig_controller_destroy/tasks/main.yml
@@ -30,5 +30,13 @@
     wait: yes
   with_items: "{{ mig_cluster_role_bindings }}"
 
+- name: Destroy manager cluster role
+  k8s:
+    state: absent
+    api_version: rbac.authorization.k8s.io/v1beta1
+    kind: ClusterRole
+    name: manager-role
+    wait: yes
+
 - name: Destroy s3 bucket if present
   include: destroy_s3_bucket.yml


### PR DESCRIPTION
This was missing on the latest controller cleanup fixes....