### PR TITLE
Do not fail build on debug errors

### DIFF
--- a/pipeline/utils.groovy
+++ b/pipeline/utils.groovy
@@ -300,7 +300,7 @@ def teardown_s3_bucket() {
 
 def run_debug(kubeconfig) {
   withEnv([ "KUBECONFIG=${kubeconfig}" ]) {
-    sh "${DEBUG_SCRIPT} ${DEBUG_SCRIPT_ARGS}"
+    sh "${DEBUG_SCRIPT} ${DEBUG_SCRIPT_ARGS} || true"
   }
 }
 

--- a/scripts/mig_debug.sh
+++ b/scripts/mig_debug.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# Continue on errors, Jenkins runs shells -e
+set +e
+
 # Mig operator and velero logs disabled by default (they are very large), enable via script args as needed
 
 OC_BINARY=`which oc`


### PR DESCRIPTION
Jenkins will abort a build when shell commands issue any failure, this PR ensures the debugging utils will not fail a build prematurely on the pipelines and also will not abort script execution when a single command fails.