### PR TITLE
Deploy OCP4 nightly releases using agnosticd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ mig-operator/*
 config/velero_aws_creds.yml
 config/pull-secret
 config/mig_controller.yml
+ocp4_nightly_release.yml
 metadata.json
 openshift-install
 terraform*

--- a/ocp4_dump_nightly_release.yml
+++ b/ocp4_dump_nightly_release.yml
@@ -1,0 +1,7 @@
+- hosts: localhost
+  tasks:
+    - include_role:
+        name: ocp4_cluster_deploy
+        tasks_from: dump_ocp4_nightly.yml
+  vars_files:
+    - "{{ playbook_dir }}/config/defaults.yml"

--- a/pipeline/common_stages.groovy
+++ b/pipeline/common_stages.groovy
@@ -111,7 +111,7 @@ def deploy_ocp4_agnosticd(kubeconfig, cluster_version) {
           'ANSIBLE_FORCE_COLOR=true'])
           {
             ansiColor('xterm') {
-//              sh './create_ocp4_workshop.sh'
+              sh './create_ocp4_workshop.sh'
             }
           }
         }
@@ -123,15 +123,15 @@ def deploy_ocp4_agnosticd(kubeconfig, cluster_version) {
         "kubeconfig": "${kubeconfig}"
         ]
 
-//        login_vars = login_vars.collect { e -> '-e ' + e.key + '=' + e.value }
-//        ansiColor('xterm') {
-//          ansiblePlaybook(
-//            playbook: 'login.yml',
-//            extras: "${login_vars.join(' ')}",
-//            hostKeyChecking: false,
-//            unbuffered: true,
-//            colorized: true)
-//        }
+        login_vars = login_vars.collect { e -> '-e ' + e.key + '=' + e.value }
+        ansiColor('xterm') {
+          ansiblePlaybook(
+            playbook: 'login.yml',
+            extras: "${login_vars.join(' ')}",
+            hostKeyChecking: false,
+            unbuffered: true,
+            colorized: true)
+        }
       }
   }
 }

--- a/pipeline/common_stages.groovy
+++ b/pipeline/common_stages.groovy
@@ -3,8 +3,11 @@ def deploy_ocp4_agnosticd(kubeconfig, cluster_version) {
 
   def repo_version = "${cluster_version}"
   def short_version = cluster_version.replace(".", "")
+
+  // Even for nightly releases, osrelease must map to a valid 4.x value on agnosticd repos (clientvm/bastion req)
   def releases = [
     '4.1': "4.1.0",
+    'nightly': "4.1.0",
   ]
   def osrelease = releases["${repo_version}"]
   def full_cluster_name = ''
@@ -27,6 +30,18 @@ def deploy_ocp4_agnosticd(kubeconfig, cluster_version) {
     [$class: 'UsernamePasswordMultiBinding', credentialsId: "${OCP4_CREDENTIALS}", usernameVariable: 'OCP4_ADMIN_USER', passwordVariable: 'OCP4_ADMIN_PASSWD']]) {
     cluster_adm_user = "${OCP4_ADMIN_USER}"
     cluster_adm_passwd = "${OCP4_ADMIN_PASSWD}"
+  }
+
+  if ("${cluster_version}" == "nightly") {
+    echo "Cluster is a nightly build"
+    // Fetch and dump OCP4 nightly release data
+    ansiColor('xterm') {
+      ansiblePlaybook(
+        playbook: 'ocp4_dump_nightly_release.yml',
+        hostKeyChecking: false,
+        unbuffered: true,
+        colorized: true)
+    }
   }
 
   sh "cp -R mig-agnosticd/4.x mig-agnosticd/${cluster_version}"
@@ -78,6 +93,17 @@ def deploy_ocp4_agnosticd(kubeconfig, cluster_version) {
             'archive_dir': "{{ output_dir | dirname }}/archive"
           ]
           writeYaml file: 'ocp4_vars.yml', data: ocp4_vars
+
+          // Add extra vars for nightly builds
+          if ("${cluster_version}" == "nightly") {
+            def ocp4_data = readYaml file: 'ocp4_vars.yml'
+            def ocp4_nightly_data = readYaml file: '../ocp4_nightly_release.yml'
+            ocp4_data.ocp4_installer_use_dev_preview = "true"
+            ocp4_data.ocp4_installer_url = ocp4_nightly_data.ocp4_installer_url
+            ocp4_data.ocp4_client_url = ocp4_nightly_data.ocp4_client_url
+            sh 'rm -f ocp4_vars.yml'
+            writeYaml file: 'ocp4_vars.yml', data: ocp4_data
+          }
           
           withEnv([
           'PATH+EXTRA=~/.local/bin',
@@ -85,7 +111,7 @@ def deploy_ocp4_agnosticd(kubeconfig, cluster_version) {
           'ANSIBLE_FORCE_COLOR=true'])
           {
             ansiColor('xterm') {
-              sh './create_ocp4_workshop.sh'
+//              sh './create_ocp4_workshop.sh'
             }
           }
         }
@@ -97,15 +123,15 @@ def deploy_ocp4_agnosticd(kubeconfig, cluster_version) {
         "kubeconfig": "${kubeconfig}"
         ]
 
-        login_vars = login_vars.collect { e -> '-e ' + e.key + '=' + e.value }
-        ansiColor('xterm') {
-          ansiblePlaybook(
-            playbook: 'login.yml',
-            extras: "${login_vars.join(' ')}",
-            hostKeyChecking: false,
-            unbuffered: true,
-            colorized: true)
-        }
+//        login_vars = login_vars.collect { e -> '-e ' + e.key + '=' + e.value }
+//        ansiColor('xterm') {
+//          ansiblePlaybook(
+//            playbook: 'login.yml',
+//            extras: "${login_vars.join(' ')}",
+//            hostKeyChecking: false,
+//            unbuffered: true,
+//            colorized: true)
+//        }
       }
   }
 }

--- a/pipeline/common_stages.groovy
+++ b/pipeline/common_stages.groovy
@@ -97,7 +97,7 @@ def deploy_ocp4_agnosticd(kubeconfig, cluster_version) {
           // Add extra vars for nightly builds
           if ("${cluster_version}" == "nightly") {
             def ocp4_data = readYaml file: 'ocp4_vars.yml'
-            def ocp4_nightly_data = readYaml file: '../ocp4_nightly_release.yml'
+            def ocp4_nightly_data = readYaml file: "${WORKSPACE}/ocp4_nightly_release.yml"
             ocp4_data.ocp4_installer_use_dev_preview = "true"
             ocp4_data.ocp4_installer_url = ocp4_nightly_data.ocp4_installer_url
             ocp4_data.ocp4_client_url = ocp4_nightly_data.ocp4_client_url

--- a/pipeline/ocp4-base.groovy
+++ b/pipeline/ocp4-base.groovy
@@ -57,14 +57,9 @@ node {
           utils.prepare_workspace(SRC_CLUSTER_VERSION, '')
           utils.copy_private_keys()
           utils.copy_public_keys()
-        }
-
-        if (SRC_CLUSTER_VERSION == 'nightly') {
-          common_stages.deploy_ocp4(SOURCE_KUBECONFIG, SRC_CLUSTER_VERSION).call()
-        } else {
           utils.prepare_agnosticd()
-          common_stages.deploy_ocp4_agnosticd(SOURCE_KUBECONFIG, SRC_CLUSTER_VERSION).call()
         }
+          common_stages.deploy_ocp4_agnosticd(SOURCE_KUBECONFIG, SRC_CLUSTER_VERSION).call()
 
     } catch (Exception ex) {
         currentBuild.result = "FAILED"
@@ -73,11 +68,7 @@ node {
         utils.notifyBuild(currentBuild.result)
         stage('Clean Up Environment') {
           if (EC2_TERMINATE_INSTANCES) {
-            if (SRC_CLUSTER_VERSION == 'nightly') {
-               utils.teardown_ocp4()
-            } else {
-               utils.teardown_ocp_agnosticd(SRC_CLUSTER_VERSION)
-            }
+            utils.teardown_ocp4()
           }
           if (CLEAN_WORKSPACE) {
             cleanWs cleanWhenFailure: false, notFailBuild: true

--- a/pipeline/ocp4-base.groovy
+++ b/pipeline/ocp4-base.groovy
@@ -68,7 +68,7 @@ node {
         utils.notifyBuild(currentBuild.result)
         stage('Clean Up Environment') {
           if (EC2_TERMINATE_INSTANCES) {
-            utils.teardown_ocp4()
+            utils.teardown_ocp_agnosticd(SRC_CLUSTER_VERSION)
           }
           if (CLEAN_WORKSPACE) {
             cleanWs cleanWhenFailure: false, notFailBuild: true

--- a/pipeline/parallel-base.groovy
+++ b/pipeline/parallel-base.groovy
@@ -106,23 +106,14 @@ node {
               if (SRC_IS_OCP3 == 'true') {
                 common_stages.deploy_ocp3_agnosticd(SOURCE_KUBECONFIG, SRC_CLUSTER_VERSION).call()
               } else {
-                  if (SRC_CLUSTER_VERSION == 'nightly') {
-                    common_stages.deploy_ocp4(SOURCE_KUBECONFIG, SRC_CLUSTER_VERSION).call()
-                  } else {
-                      common_stages.deploy_ocp4_agnosticd(SOURCE_KUBECONFIG, SRC_CLUSTER_VERSION).call()
-                    }
+                  common_stages.deploy_ocp4_agnosticd(SOURCE_KUBECONFIG, SRC_CLUSTER_VERSION).call()
                 }
             }, deploy_dest_cluster: {
                  if (DEST_IS_OCP3 == 'true') {
                  common_stages.deploy_ocp3_agnosticd(TARGET_KUBECONFIG, DEST_CLUSTER_VERSION).call()
               } else {
-                  if (DEST_CLUSTER_VERSION == 'nightly') {
-                    common_stages.deploy_ocp4(TARGET_KUBECONFIG, DEST_CLUSTER_VERSION).call()
-                  } else {
-                      common_stages.deploy_ocp4_agnosticd(TARGET_KUBECONFIG, DEST_CLUSTER_VERSION).call()
+                  common_stages.deploy_ocp4_agnosticd(TARGET_KUBECONFIG, DEST_CLUSTER_VERSION).call()
                     }
-                }
-
             },
             failFast: true
         }
@@ -147,18 +138,9 @@ node {
         stage('Clean Up Environment') {
           if (EC2_TERMINATE_INSTANCES) {
             parallel destroy_src_cluster: {
-              if (SRC_CLUSTER_VERSION == 'nightly') {
-                utils.teardown_ocp4()
-              } else {
-                  utils.teardown_ocp_agnosticd(SRC_CLUSTER_VERSION)
-                }
+              utils.teardown_ocp_agnosticd(SRC_CLUSTER_VERSION)
             }, destroy_dest_cluster: {
-
-              if (DEST_CLUSTER_VERSION == 'nightly') {
-                utils.teardown_ocp4()
-              } else {
-                  utils.teardown_ocp_agnosticd(DEST_CLUSTER_VERSION)
-                }
+              utils.teardown_ocp_agnosticd(DEST_CLUSTER_VERSION)
             },
             failFast: false
             utils.teardown_s3_bucket()

--- a/roles/ocp4_cluster_deploy/tasks/dump_ocp4_nightly.yml
+++ b/roles/ocp4_cluster_deploy/tasks/dump_ocp4_nightly.yml
@@ -1,0 +1,31 @@
+- name: Fetch OCP4 nightly release content
+  uri:
+    url: "{{ openshift_installer_release_prefix_url }}/{{ openshift_parent_dir_choices['nightly'] }}/latest"
+    return_content: yes
+  register: page
+  until: page is success
+  retries: 12
+  delay: 10
+
+- name: Determine OCP4 nightly installer release
+  set_fact:
+    installer_latest_release: "{{ page.content | regex_findall('<a.*openshift-install[^<]+?>') | last | regex_search(openshift_installer_regex_choices['nightly']) }}"
+
+- name: Determine OCP4 nightly client release
+  set_fact:
+    client_latest_release: "{{ page.content | regex_findall('<a.*openshift-client[^<]+?>') | last | regex_search(openshift_installer_regex_choices['nightly']) }}"
+
+- name: Set variables to OCP4 nightly release
+  set_fact:
+    openshift_installer_release_url: "{{ openshift_installer_release_prefix_url }}/{{ openshift_parent_dir_choices['nightly'] }}/latest/openshift-install-linux-{{ installer_latest_release }}.tar.gz"
+    openshift_client_release_url: "{{ openshift_installer_release_prefix_url }}/{{ openshift_parent_dir_choices['nightly'] }}/latest/openshift-client-linux-{{ client_latest_release }}.tar.gz"
+
+- debug:
+    msg: 
+    - "OCP4 nightly installer release : {{ openshift_installer_release_url }}"
+    - "OCP4 nightly client release : {{ openshift_client_release_url }}"
+
+- name: Write nightly release to ocp4_nightly_release.yml
+  template:
+    src: ocp4_nightly_release.yml.j2
+    dest: "{{ playbook_dir }}/ocp4_nightly_release.yml"

--- a/roles/ocp4_cluster_deploy/templates/ocp4_nightly_release.yml.j2
+++ b/roles/ocp4_cluster_deploy/templates/ocp4_nightly_release.yml.j2
@@ -1,0 +1,2 @@
+ocp4_installer_url: {{ openshift_installer_release_url }}
+ocp4_client_url: {{ openshift_client_release_url }}


### PR DESCRIPTION
This PR implements agnosticd ability to pull nightly releases from ocp-dev-preview. It eliminates the need for an extra ocp4 role for this task and consolidates all deployments on agnosticd.

- Use  ocp4_dump_nightly_release.yml playbook to fetch latest nightly build from ocp-dev-preview
- Nightly release info is consumed by deploy_ocp4_agnosticd common stage and corresponding agnosticd variables are set
- Pipelines updated and simplified to reflect these changes
