### PR TITLE
Use OLM for OCP4

### DIFF
--- a/pipeline/common_stages.groovy
+++ b/pipeline/common_stages.groovy
@@ -6,7 +6,7 @@ def deploy_ocp4_agnosticd(kubeconfig, cluster_version) {
 
   // Even for nightly releases, osrelease must map to a valid 4.x value on agnosticd repos (clientvm/bastion req)
   def releases = [
-    '4.1': "4.1.0",
+    '4.1': "4.1.13",
     'nightly': "4.1.0",
   ]
   def osrelease = releases["${repo_version}"]
@@ -410,12 +410,24 @@ def deploy_mig_controller_on_both(
           mig_controller_tag = "${MIG_CONTROLLER_TAG}"
       }
 
+      def SRC_USE_OLM = false
+      def DEST_USE_OLM = false
+      if (USE_OLM) {
+        if (SRC_CLUSTER_VERSION.startsWith("4.")) {
+          SRC_USE_OLM = true
+        }
+        if (DEST_CLUSTER_VERSION.startsWith("4.")) {
+          DEST_USE_OLM = true
+        }
+      } 
+
       // Source
       withEnv([
           "KUBECONFIG=${source_kubeconfig}",
           "MIG_CONTROLLER_IMG=${mig_controller_img}",
           "MIG_CONTROLLER_TAG=${mig_controller_tag}",
           "MIG_OPERATOR_TAG=${MIG_OPERATOR_TAG}",
+          "MIG_OPERATOR_USE_OLM=${SRC_USE_OLM}",
           "MIG_UI_TAG=${MIG_UI_TAG}",
           "MIG_VELERO_TAG=${MIG_VELERO_TAG}",
           "MIG_VELERO_PLUGIN_TAG=${MIG_VELERO_PLUGIN_TAG}",
@@ -435,6 +447,7 @@ def deploy_mig_controller_on_both(
           "MIG_CONTROLLER_IMG=${mig_controller_img}",
           "MIG_CONTROLLER_TAG=${mig_controller_tag}",
           "MIG_OPERATOR_TAG=${MIG_OPERATOR_TAG}",
+          "MIG_OPERATOR_USE_OLM=${DEST_USE_OLM}",
           "MIG_UI_TAG=${MIG_UI_TAG}",
           "MIG_VELERO_TAG=${MIG_VELERO_TAG}",
           "MIG_VELERO_PLUGIN_TAG=${MIG_VELERO_PLUGIN_TAG}",

--- a/pipeline/parallel-base.groovy
+++ b/pipeline/parallel-base.groovy
@@ -50,11 +50,14 @@ booleanParam(defaultValue: true, description: 'Run e2e tests', name: 'E2E_RUN'),
 booleanParam(defaultValue: false, description: 'Update OCP3 cluster packages to latest', name: 'OCP3_UPDATE'),
 booleanParam(defaultValue: true, description: 'Provision glusterfs workload on OCP3', name: 'OCP3_GLUSTERFS'),
 booleanParam(defaultValue: true, description: 'Provision CEPH workload on destination cluster', name: 'CEPH'),
+booleanParam(defaultValue: true, description: 'Deploy mig operator using OLM on OCP4', name: 'USE_OLM'),
 booleanParam(defaultValue: true, description: 'Clean up workspace after build', name: 'CLEAN_WORKSPACE'),
 booleanParam(defaultValue: false, description: 'Persistent cluster builds with fixed hostname', name: 'PERSISTENT'),
 booleanParam(defaultValue: false, description: 'Enable debugging', name: 'DEBUG'),
 booleanParam(defaultValue: true, description: 'EC2 terminate instances after build', name: 'EC2_TERMINATE_INSTANCES')])])
 
+// true/false build parameter that defines if we use OLM to deploy mig operator on OCP4
+USE_OLM = params.USE_OLM
 // true/false build parameter that defines if we terminate instances once build is done
 def EC2_TERMINATE_INSTANCES = params.EC2_TERMINATE_INSTANCES
 // true/false build parameter that defines if we cleanup workspace once build is done
@@ -116,7 +119,9 @@ node {
                  common_stages.deploy_ocp3_agnosticd(TARGET_KUBECONFIG, DEST_CLUSTER_VERSION).call()
               } else {
                   common_stages.deploy_ocp4_agnosticd(TARGET_KUBECONFIG, DEST_CLUSTER_VERSION).call()
-                  common_stages.deploy_ceph(DEST_CLUSTER_VERSION).call()
+                  if (CEPH) {
+                    common_stages.deploy_ceph(DEST_CLUSTER_VERSION).call()
+                }
                     }
             },
             failFast: true

--- a/roles/login_ocp/tasks/login.yml
+++ b/roles/login_ocp/tasks/login.yml
@@ -16,8 +16,8 @@
   - name: Login to cluster
     shell: "{{ oc_binary }} login -u {{ user }} -p {{ passwd }} {{ console_addr }} --insecure-skip-tls-verify=true"
     register: login
-    retries: 20
-    delay: 6
+    retries: 30
+    delay: 10
     until: login.rc == 0
     environment:
       KUBECONFIG: "{{ kubeconfig }}"

--- a/roles/mig_controller_deploy/templates/controller.yml.j2
+++ b/roles/mig_controller_deploy/templates/controller.yml.j2
@@ -8,9 +8,13 @@ spec:
   migration_velero: {{ mig_controller_velero }}
   migration_controller: {{ mig_controller_host_cluster }}
   migration_ui: {{ mig_controller_ui }}
+  olm_managed: {{ mig_operator_use_olm }}
   mig_controller_image: {{ mig_controller_img }}
   mig_controller_version: {{ mig_controller_tag }}
   mig_ui_image: {{ mig_ui_img }}
+{% if mig_operator_tag == 'stable' %}
+  snapshot_tag: {{ mig_operator_tag }}
+{% endif %}
   mig_ui_version: {{ mig_ui_tag }}
   velero_image: {{ mig_velero_img }}
   velero_version: {{ mig_velero_tag }}

--- a/roles/mig_controller_prereqs/defaults/main.yml
+++ b/roles/mig_controller_prereqs/defaults/main.yml
@@ -9,6 +9,7 @@ mig_controller_img: "{{ lookup('env', 'MIG_CONTROLLER_IMG') or 'quay.io/ocpmigra
 mig_controller_tag: "{{ lookup('env', 'MIG_CONTROLLER_TAG') or 'latest' }}"
 mig_operator_img: "{{ lookup('env', 'MIG_OPERATOR_IMG') or 'quay.io/ocpmigrate/mig-operator' }}"
 mig_operator_tag: "{{ lookup('env', 'MIG_OPERATOR_TAG') or 'latest' }}"
+mig_operator_use_olm: "{{ lookup('env', 'MIG_OPERATOR_USE_OLM') or 'false' }}"
 mig_ui_img: "{{ lookup('env', 'MIG_UI_IMG') or 'quay.io/ocpmigrate/mig-ui' }}"
 mig_ui_tag: "{{ lookup('env', 'MIG_UI_TAG') or 'latest' }}"
 mig_velero_img: "{{ lookup('env', 'MIG_VELERO_IMG') or 'quay.io/ocpmigrate/velero' }}"

--- a/roles/mig_controller_prereqs/tasks/deploy_operator.yml
+++ b/roles/mig_controller_prereqs/tasks/deploy_operator.yml
@@ -12,12 +12,83 @@
   when: not op_repo.stat.exists
 
 - debug:
-    msg: "Mig operator will deploy using release : {{ mig_operator_tag }}"
+    msg: 
+      - "Mig operator will deploy using OLM : {{ mig_operator_use_olm }}"
+      - "Mig operator will deploy using release : {{ mig_operator_tag }}"
 
+- name: "Deploy mig operator using OLM"
+  block:
+
+    - name: "Create OperatorSource"
+      k8s:
+        state: present
+        definition: "{{ lookup('file', '{{ mig_operator_location }}/mig-operator-source.yaml' )}}"
+      register: mig_operator_source_created
+      until: mig_operator_source_created is succeeded
+      retries: 30
+      delay: 30
+
+    - name: "Wait for OperatorSource to settle"
+      wait_for:
+        timeout: 90
+
+    - name: "Wait for OLM to reconcile OperatorSource creation"
+      k8s_facts:
+        kind: Pod
+        namespace: openshift-marketplace
+        label_selectors: "marketplace.catalogSourceConfig=ocpmigrate-operators"
+      register: pod
+      until: "true in (pod | json_query('resources[].status.containerStatuses[].ready'))"
+      retries: 60
+      delay: 45
+
+    - name: "Confirm service availability"
+      k8s_facts:
+        kind: Service
+        namespace: openshift-marketplace
+        name: ocpmigrate-operators
+        label_selectors: "marketplace.catalogSourceConfig=ocpmigrate-operators"
+      register: service
+      until: "'grpc' in (service | json_query('resources[].spec.ports[].name'))"
+      retries: 15
+      delay: 10
+
+    - name: "Create {{ mig_migration_namespace }} namespace"
+      k8s:
+        name: "{{ mig_migration_namespace }}"
+        kind: Namespace
+        state: present
+      
+    - name: "Get grpc_endpoint IP:port of ocpmigrate-operators service"
+      set_fact:
+        grpc_endpoint: "{{ service | json_query('resources[0].spec.clusterIP') }}:{{ service | json_query('resources[0].spec.ports[0].port') }}"
+
+    - name: "Create CatalogSource"
+      k8s:
+        state: present
+        definition: "{{ lookup('template', 'mig-operator-catalogsource.yml.j2' ) }}"
+
+    - name: "Create OperatorGroup"
+      k8s:
+        state: present
+        definition: "{{ lookup('template', 'mig-operator-operatorgroup.yml.j2' ) }}"
+
+    - name: "Create Subscription"
+      k8s:
+        state: present
+        definition: "{{ lookup('template', 'mig-operator-subscription.yml.j2' ) }}"
+
+  when: mig_operator_use_olm|bool 
+      
 - name: Deploy mig operator
   k8s:
     state : present
     definition: "{{ lookup('file', '{{ mig_operator_location }}/deploy/non-olm/{{ mig_operator_tag }}/operator.yml' )}}"
+  when: not mig_operator_use_olm|bool 
+
+- name: "Wait for mig operator deployment to settle"
+  wait_for:
+    timeout: 45
 
 - name: Check status of mig operator
   k8s_facts:

--- a/roles/mig_controller_prereqs/templates/mig-operator-catalogsource.yml.j2
+++ b/roles/mig_controller_prereqs/templates/mig-operator-catalogsource.yml.j2
@@ -1,0 +1,13 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  labels:
+    csc-owner-name: installed-custom-openshift-migration
+    csc-owner-namespace: openshift-marketplace
+  name: installed-custom-openshift-migration
+  namespace: {{ mig_migration_namespace }}
+spec:
+  sourceType: grpc
+  address: {{ grpc_endpoint }}
+  displayName: Custom Operators
+  publisher: Custom

--- a/roles/mig_controller_prereqs/templates/mig-operator-operatorgroup.yml.j2
+++ b/roles/mig_controller_prereqs/templates/mig-operator-operatorgroup.yml.j2
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1alpha2
+kind: OperatorGroup
+metadata:
+  name: {{ mig_migration_namespace  }}
+  namespace: {{ mig_migration_namespace  }}
+spec:  
+  targetNamespaces:
+  - {{ mig_migration_namespace  }}

--- a/roles/mig_controller_prereqs/templates/mig-operator-subscription.yml.j2
+++ b/roles/mig_controller_prereqs/templates/mig-operator-subscription.yml.j2
@@ -1,0 +1,20 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: mig-operator
+  namespace: {{ mig_migration_namespace }}
+spec:
+{% if mig_operator_tag == 'v1.0.0' %}
+  channel: release-v1
+{% else %}
+  channel: {{ mig_operator_tag }}
+{% endif %}
+  installPlanApproval: Automatic
+  name: mig-operator
+  source: installed-custom-openshift-migration
+  sourceNamespace: {{ mig_migration_namespace }}
+{% if mig_operator_tag == 'release-v1' %}
+  startingCSV: mig-operator.v1.0.0
+{% else %}
+  startingCSV: mig-operator.{{ mig_operator_tag }}
+{% endif %}

--- a/roles/ocp4_cluster_deploy/tasks/dump_ocp4_nightly.yml
+++ b/roles/ocp4_cluster_deploy/tasks/dump_ocp4_nightly.yml
@@ -4,7 +4,7 @@
     return_content: yes
   register: page
   until: page is success
-  retries: 12
+  retries: 15
   delay: 10
 
 - name: Determine OCP4 nightly installer release

--- a/roles/ocp4_cluster_deploy/tasks/idp.yml
+++ b/roles/ocp4_cluster_deploy/tasks/idp.yml
@@ -18,8 +18,8 @@
 
 - name: Login as {{ ocp4_admin_user }}
   shell: "{{ oc_binary }} login -u {{ ocp4_admin_user }} -p {{ ocp4_admin_password }} --insecure-skip-tls-verify=true"
-  retries: 12
-  delay: 10
+  retries: 45
+  delay: 15
   register: result
   until: result is succeeded
 


### PR DESCRIPTION
### Add support for using OLM to deploy mig-operator on OCP4 clusters.

---
`pipeline/common_stages.groovy`:
* Version: `4.1.0` -> `4.1.13`
* Add variables and logic to support using OLM bool

---
`pipeline/parallel-base.groovy`:
* Add variable for using OLM

---
`roles/mig_controller_deploy/templates/controller.yml.j2`:
* Add logic to template to support `stable`
* Add option for OLM bool

---
`roles/mig_controller_prereqs/defaults/main.yml`:
* Add variable for OLM, default to `false`

---
`roles/mig_controller_prereqs/tasks/deploy_operator.yml`
* Add tasks block for using OLM

---
`roles/mig_controller_prereqs/templates/mig-operator-catalogsource.yml.j2`,
`roles/mig_controller_prereqs/templates/mig-operator-operatorgroup.yml.j2`,
`roles/mig_controller_prereqs/templates/mig-operator-subscription.yml.j2`
* New templates for using mig-operator with OLM

---
`roles/ocp4_cluster_deploy/tasks/idp.yml`, 
`roles/ocp4_cluster_deploy/tasks/dump_ocp4_nightly.yml`, 
`roles/login_ocp/tasks/login.yml`:
* Adjust retries & delay values
