### PR TITLE
Unwrap deploy_ceph call()

### DIFF
--- a/pipeline/parallel-base.groovy
+++ b/pipeline/parallel-base.groovy
@@ -119,9 +119,7 @@ node {
                  common_stages.deploy_ocp3_agnosticd(TARGET_KUBECONFIG, DEST_CLUSTER_VERSION).call()
               } else {
                   common_stages.deploy_ocp4_agnosticd(TARGET_KUBECONFIG, DEST_CLUSTER_VERSION).call()
-                  if (CEPH) {
-                    common_stages.deploy_ceph(DEST_CLUSTER_VERSION).call()
-                }
+                  common_stages.deploy_ceph(DEST_CLUSTER_VERSION).call()
                     }
             },
             failFast: true


### PR DESCRIPTION
Reverts https://github.com/fusor/mig-ci/commit/a02d74999e20bbaac0056929879addf50df370cc "CEPH=false, Cannot invoke method call() on null object" 

Addressed in https://github.com/fusor/mig-ci/pull/129