### PR TITLE
Fix destroy script

### DIFF
--- a/pipeline/common_stages.groovy
+++ b/pipeline/common_stages.groovy
@@ -387,6 +387,7 @@ def deploy_mig_controller_on_both(
   mig_controller_dst) {
   // mig_controller_src boolean defines if the source cluster will host mig controller
   // mig_controller_dst boolean defines if the destination cluster will host mig controller
+  sh "echo 'ansible-playbook s3_bucket_destroy.yml &' >> destroy_env.sh"
   return {
     stage('Build mig-controller image and deploy on both clusters') {
       steps_finished << 'Build mig-controller image and deploy on both clusters'

--- a/pipeline/common_stages.groovy
+++ b/pipeline/common_stages.groovy
@@ -45,6 +45,7 @@ def deploy_ocp4_agnosticd(kubeconfig, cluster_version) {
   }
 
   sh "cp -R mig-agnosticd/4.x mig-agnosticd/${cluster_version}"
+  sh "echo 'cd mig-agnosticd/${cluster_version} && ./delete_ocp4_workshop.sh &' >> destroy_env.sh"
   return {
     stage('Deploy agnosticd OCP workshop ' + cluster_version) {
       steps_finished << 'Deploy agnosticd OCP workshop ' + cluster_version
@@ -170,6 +171,7 @@ def deploy_ocp3_agnosticd(kubeconfig, cluster_version) {
   }
 
   sh "cp -R mig-agnosticd/3.x mig-agnosticd/${cluster_version}"
+  sh "echo 'cd mig-agnosticd/${cluster_version} && ./delete_ocp3_workshop.sh &' >> destroy_env.sh"
   return {
     stage('Deploy agnosticd OCP workshop ' + cluster_version) {
       steps_finished << 'Deploy agnosticd OCP workshop ' + cluster_version

--- a/pipeline/utils.groovy
+++ b/pipeline/utils.groovy
@@ -65,7 +65,7 @@ def prepare_agnosticd() {
   checkout([$class: 'GitSCM', branches: [[name: 'master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'mig-agnosticd']], submoduleCfg: [], userRemoteConfigs: [[url: 'https://github.com/fusor/mig-agnosticd.git']]])
   // Set agnosticd HOME and add to destroy script
   AGNOSTICD_HOME = "${env.WORKSPACE}/agnosticd"
-  sh "echo 'export AGNOSTICD_HOME=${AGNOSTICD_HOME}/agnosticd' >> destroy_env.sh"
+  sh "echo 'export AGNOSTICD_HOME=${AGNOSTICD_HOME}' >> destroy_env.sh"
   
   withCredentials([
     string(credentialsId: "$EC2_ACCESS_KEY_ID", variable: 'AWS_ACCESS_KEY_ID'),

--- a/pipeline/utils.groovy
+++ b/pipeline/utils.groovy
@@ -123,6 +123,7 @@ def prepare_workspace(src_version = '', dest_version = '') {
 
   OC_BINARY = "${env.WORKSPACE}/bin/oc"
   sh 'touch destroy_env.sh && chmod +x destroy_env.sh'
+  sh "echo 'export AWS_REGION=${AWS_REGION} AWS_ACCESS_KEY=${AWS_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}' >> destroy_env.sh"
 }
 
 

--- a/pipeline/utils.groovy
+++ b/pipeline/utils.groovy
@@ -63,9 +63,9 @@ def prepare_agnosticd() {
   checkout([$class: 'GitSCM', branches: [[name: 'development']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'agnosticd']], submoduleCfg: [], userRemoteConfigs: [[url: 'https://github.com/redhat-cop/agnosticd.git']]])
 
   checkout([$class: 'GitSCM', branches: [[name: 'master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'mig-agnosticd']], submoduleCfg: [], userRemoteConfigs: [[url: 'https://github.com/fusor/mig-agnosticd.git']]])
-
-  // Set agnosticd HOME
+  // Set agnosticd HOME and add to destroy script
   AGNOSTICD_HOME = "${env.WORKSPACE}/agnosticd"
+  sh "echo 'export AGNOSTICD_HOME=${AGNOSTICD_HOME}/agnosticd' >> destroy_env.sh"
   
   withCredentials([
     string(credentialsId: "$EC2_ACCESS_KEY_ID", variable: 'AWS_ACCESS_KEY_ID'),

--- a/pipeline/utils.groovy
+++ b/pipeline/utils.groovy
@@ -89,6 +89,7 @@ def prepare_agnosticd() {
           ]
         writeYaml file: 'secret.yml', data: secret_vars
         }
+       sh "echo 'export AWS_REGION=${AWS_REGION} AWS_ACCESS_KEY=${AWS_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}' >> destroy_env.sh"
      }
 }
 
@@ -123,7 +124,6 @@ def prepare_workspace(src_version = '', dest_version = '') {
 
   OC_BINARY = "${env.WORKSPACE}/bin/oc"
   sh 'touch destroy_env.sh && chmod +x destroy_env.sh'
-  sh "echo 'export AWS_REGION=${AWS_REGION} AWS_ACCESS_KEY=${AWS_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}' >> destroy_env.sh"
 }
 
 


### PR DESCRIPTION
The destroy script was out of sync since the last updates to agnosticd deployment common methods, this script can be used to destroy the built environment without Jenkins pipeline assistance, either command line on Jenkins server or called by another script/job.
