### PR TITLE
Cephfs deployment pause

### DIFF
--- a/pipeline/common_stages.groovy
+++ b/pipeline/common_stages.groovy
@@ -262,6 +262,7 @@ def deploy_ceph(cluster_version) {
     if (CEPH) {
       stage('Deploy CEPH workload on ' + cluster_version) {
         steps_finished << 'Deploy CEPH workload on ' + cluster_version
+        sh 'sleep 60'
         dir("mig-agnosticd/workloads") {
           withEnv([
             "AGNOSTICD_HOME=${AGNOSTICD_HOME}",

--- a/pipeline/common_stages.groovy
+++ b/pipeline/common_stages.groovy
@@ -262,7 +262,7 @@ def deploy_ceph(cluster_version) {
     if (CEPH) {
       stage('Deploy CEPH workload on ' + cluster_version) {
         steps_finished << 'Deploy CEPH workload on ' + cluster_version
-        sh 'sleep 60'
+        sh 'sleep 120'
         dir("mig-agnosticd/workloads") {
           withEnv([
             "AGNOSTICD_HOME=${AGNOSTICD_HOME}",

--- a/pipeline/common_stages.groovy
+++ b/pipeline/common_stages.groovy
@@ -262,7 +262,7 @@ def deploy_ceph(cluster_version) {
     if (CEPH) {
       stage('Deploy CEPH workload on ' + cluster_version) {
         steps_finished << 'Deploy CEPH workload on ' + cluster_version
-        sh 'sleep 120'
+        sh 'sleep 180'
         dir("mig-agnosticd/workloads") {
           withEnv([
             "AGNOSTICD_HOME=${AGNOSTICD_HOME}",


### PR DESCRIPTION
Allow cluster APIs to settle before attempting to add cephfs storage during deployment, it prevents different issues that arise when clusters are still coming up and cephfs workload role attempts to create storage.

Tested on ci-mig-e2e-base pipeline