### PR TITLE
Sync mig_controller_destroy with latest operator

### DIFF
--- a/roles/mig_controller_destroy/defaults/main.yml
+++ b/roles/mig_controller_destroy/defaults/main.yml
@@ -16,3 +16,8 @@ mig_cluster_role_bindings:
   - migration-operator
   - velero
   - mig-cluster-admin
+  - migration-manager-rolebinding
+  - manager-rolebinding
+mig_cluster_roles:
+  - migration-manager-role
+  - manager-role

--- a/roles/mig_controller_destroy/tasks/main.yml
+++ b/roles/mig_controller_destroy/tasks/main.yml
@@ -10,7 +10,7 @@
     kind: Namespace
     name: "{{ mig_migration_namespace }}"
     wait: yes
-    wait_timeout: 300
+    wait_timeout: 3600
 
 - name: Destroy velero CRDs
   k8s:
@@ -35,8 +35,9 @@
     state: absent
     api_version: rbac.authorization.k8s.io/v1beta1
     kind: ClusterRole
-    name: manager-role
+    name: "{{ item }}" 
     wait: yes
+  with_items: "{{ mig_cluster_roles }}"
 
 - name: Destroy s3 bucket if present
   include: destroy_s3_bucket.yml


### PR DESCRIPTION
- Add missing cluster roles and bindings to sync with latest operator
  removal procedure
- Increase NS removal timeout to 3600 seconds