### PR TITLE
Fix velero restic restore helper issues with v1.0

### DIFF
--- a/pipeline/parallel-base.groovy
+++ b/pipeline/parallel-base.groovy
@@ -32,6 +32,7 @@ string(defaultValue: 'latest', description: 'Mig controller version/tag to deplo
 string(defaultValue: 'latest', description: 'Mig ui version/tag to deploy', name: 'MIG_UI_TAG', trim: false),
 string(defaultValue: 'latest', description: 'Mig velero version/tag to deploy', name: 'MIG_VELERO_TAG', trim: false),
 string(defaultValue: 'latest', description: 'Mig velero plugin version/tag to deploy', name: 'MIG_VELERO_PLUGIN_TAG', trim: false),
+string(defaultValue: 'latest', description: 'Mig velero restic restore helper version/tag to deploy', name: 'MIG_VELERO_RESTIC_RESTORE_HELPER_TAG', trim: false),
 string(defaultValue: 'scripts/mig_debug.sh', description: 'Relative file path to debug script on MIG CI repo', name: 'DEBUG_SCRIPT', trim: false),
 string(defaultValue: '', description: 'Extra debug script arguments', name: 'DEBUG_SCRIPT_ARGS', trim: false),
 string(defaultValue: 'quay.io/fbladilo/mig-controller', description: 'Repo for quay io for custom mig-controller images, only used by GHPRB', name: 'QUAYIO_CI_REPO', trim: false),

--- a/roles/mig_controller_deploy/tasks/deploy.yml
+++ b/roles/mig_controller_deploy/tasks/deploy.yml
@@ -5,6 +5,7 @@
          {{ mig_ui_img }}:{{ mig_ui_tag }}
          {{ mig_velero_img }}:{{ mig_velero_tag }}
          {{ mig_velero_plugin_img }}:{{ mig_velero_plugin_tag }}
+         {{ mig_velero_restic_restore_helper_img }}:{{ mig_velero_restic_restore_helper_tag }}
 
 - name: Deploy mig controller
   k8s:

--- a/roles/mig_controller_deploy/templates/controller.yml.j2
+++ b/roles/mig_controller_deploy/templates/controller.yml.j2
@@ -20,6 +20,8 @@ spec:
   velero_version: {{ mig_velero_tag }}
   velero_plugin_image: {{ mig_velero_plugin_img }}
   velero_plugin_version: {{ mig_velero_plugin_tag }}
+  velero_restic_restore_helper_image: {{ mig_velero_restic_restore_helper_img }}
+  velero_restic_restore_helper_version: {{ mig_velero_restic_restore_helper_tag }}
 
   mig_ui_config_namespace: {{ mig_migration_namespace }}
   

--- a/roles/mig_controller_prereqs/defaults/main.yml
+++ b/roles/mig_controller_prereqs/defaults/main.yml
@@ -16,6 +16,8 @@ mig_velero_img: "{{ lookup('env', 'MIG_VELERO_IMG') or 'quay.io/ocpmigrate/veler
 mig_velero_tag: "{{ lookup('env', 'MIG_VELERO_TAG') or 'latest' }}"
 mig_velero_plugin_img: "{{ lookup('env', 'MIG_VELERO_PLUGIN_IMG') or 'quay.io/ocpmigrate/migration-plugin' }}"
 mig_velero_plugin_tag: "{{ lookup('env', 'MIG_VELERO_PLUGIN_TAG') or 'latest' }}"
+mig_velero_restic_restore_helper_img: "{{ lookup('env', 'MIG_VELERO_RESTIC_RESTORE_HELPER_IMG') or 'quay.io/ocpmigrate/velero-restic-restore-helper' }}"
+mig_velero_restic_restore_helper_tag: "{{ lookup('env', 'MIG_VELERO_RESTIC_RESTORE_HELPER_TAG') or 'latest' }}"
 mig_controller_sa_name: mig
 mig_controller_host_cluster: true
 mig_controller_velero: true


### PR DESCRIPTION
- v1.0 operator must have the restic restore helper version specified
  otherwise it fails to deploy velero