### PR TITLE
Add ability to deploy CAM GA releases

### DIFF
--- a/pipeline/common_stages.groovy
+++ b/pipeline/common_stages.groovy
@@ -466,6 +466,7 @@ def deploy_mig_controller_on_both(
       withEnv([
           "KUBECONFIG=${source_kubeconfig}",
           "MIG_OPERATOR_USE_OLM=${SRC_USE_OLM}",
+          "MIG_OPERATOR_USE_DOWNSTREAM=${USE_DOWNSTREAM}",
           "SUB_USER=${SUB_USER}",
           "SUB_PASS=${SUB_PASS}",
           "PATH+EXTRA=~/bin"]) {
@@ -482,6 +483,7 @@ def deploy_mig_controller_on_both(
       withEnv([
           "KUBECONFIG=${target_kubeconfig}",
           "MIG_OPERATOR_USE_OLM=${DEST_USE_OLM}",
+          "MIG_OPERATOR_USE_DOWNSTREAM=${USE_DOWNSTREAM}",
           "SUB_USER=${SUB_USER}",
           "SUB_PASS=${SUB_PASS}",
           "PATH+EXTRA=~/bin"]) {

--- a/pipeline/common_stages.groovy
+++ b/pipeline/common_stages.groovy
@@ -445,7 +445,7 @@ def deploy_mig_controller_on_both(
         mig_controller_tag = "${MIG_CONTROLLER_BRANCH}"
       } else {
           mig_controller_img = "quay.io/ocpmigrate/mig-controller"
-          mig_controller_tag = "${MIG_CONTROLLER_TAG}"
+          mig_controller_tag = "${MIG_CONTROLLER_BRANCH}"
       }
 
       def SRC_USE_OLM = false
@@ -458,17 +458,16 @@ def deploy_mig_controller_on_both(
           DEST_USE_OLM = true
         }
       } 
-
+      withCredentials([
+        string(credentialsId: "$EC2_SUB_USER", variable: 'SUB_USER'),
+        string(credentialsId: "$EC2_SUB_PASS", variable: 'SUB_PASS')])
+      {
       // Source
       withEnv([
           "KUBECONFIG=${source_kubeconfig}",
-          "MIG_CONTROLLER_IMG=${mig_controller_img}",
-          "MIG_CONTROLLER_TAG=${mig_controller_tag}",
-          "MIG_OPERATOR_TAG=${MIG_OPERATOR_TAG}",
           "MIG_OPERATOR_USE_OLM=${SRC_USE_OLM}",
-          "MIG_UI_TAG=${MIG_UI_TAG}",
-          "MIG_VELERO_TAG=${MIG_VELERO_TAG}",
-          "MIG_VELERO_PLUGIN_TAG=${MIG_VELERO_PLUGIN_TAG}",
+          "SUB_USER=${SUB_USER}",
+          "SUB_PASS=${SUB_PASS}",
           "PATH+EXTRA=~/bin"]) {
         ansiColor('xterm') {
           ansiblePlaybook(
@@ -482,13 +481,9 @@ def deploy_mig_controller_on_both(
       // Target
       withEnv([
           "KUBECONFIG=${target_kubeconfig}",
-          "MIG_CONTROLLER_IMG=${mig_controller_img}",
-          "MIG_CONTROLLER_TAG=${mig_controller_tag}",
-          "MIG_OPERATOR_TAG=${MIG_OPERATOR_TAG}",
           "MIG_OPERATOR_USE_OLM=${DEST_USE_OLM}",
-          "MIG_UI_TAG=${MIG_UI_TAG}",
-          "MIG_VELERO_TAG=${MIG_VELERO_TAG}",
-          "MIG_VELERO_PLUGIN_TAG=${MIG_VELERO_PLUGIN_TAG}",
+          "SUB_USER=${SUB_USER}",
+          "SUB_PASS=${SUB_PASS}",
           "PATH+EXTRA=~/bin"]) {
         ansiColor('xterm') {
           ansiblePlaybook(
@@ -499,6 +494,7 @@ def deploy_mig_controller_on_both(
             colorized: true)
         }
       }
+    }
     }
   }
 }

--- a/pipeline/mig-e2e-base.groovy
+++ b/pipeline/mig-e2e-base.groovy
@@ -23,15 +23,13 @@ credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.StringC
 credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.UsernamePasswordMultiBinding', defaultValue: 'ci_ocp4_admin_credentials', description: 'Cluster admin credentials used in OCP4 deployments', name: 'OCP4_CREDENTIALS', required: true),
 credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.UsernamePasswordMultiBinding', defaultValue: 'ci_ocp3_admin_credentials', description: 'Cluster admin credentials used in OCP3 deployments', name: 'OCP3_CREDENTIALS', required: true),
 booleanParam(defaultValue: true, description: 'Deploy mig operator using OLM on OCP4', name: 'USE_OLM'),
-booleanParam(defaultValue: false, description: 'Deploy using downstream images', name: 'USE_DOWNSTREAM'),
+booleanParam(defaultValue: false, description: 'Deploy using downstream images', name: 'MIG_OPERATOR_USE_DOWNSTREAM'),
 booleanParam(defaultValue: false, description: 'Enable debugging', name: 'DEBUG'),
 booleanParam(defaultValue: true, description: 'Clean up workspace after build', name: 'CLEAN_WORKSPACE')])])
 
 
 // true/false build parameter that defines if we use OLM to deploy mig operator on OCP4
 USE_OLM = params.USE_OLM
-// true/false build parameter that defines if we will deploy CAM/controller using downstream images
-USE_DOWNSTREAM = params.USE_DOWNSTREAM
 // true/false build parameter that defines if we cleanup workspace once build is done
 def CLEAN_WORKSPACE = params.CLEAN_WORKSPACE
 // Split e2e tests from string param

--- a/pipeline/mig-e2e-base.groovy
+++ b/pipeline/mig-e2e-base.groovy
@@ -23,7 +23,7 @@ credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.StringC
 credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.UsernamePasswordMultiBinding', defaultValue: 'ci_ocp4_admin_credentials', description: 'Cluster admin credentials used in OCP4 deployments', name: 'OCP4_CREDENTIALS', required: true),
 credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.UsernamePasswordMultiBinding', defaultValue: 'ci_ocp3_admin_credentials', description: 'Cluster admin credentials used in OCP3 deployments', name: 'OCP3_CREDENTIALS', required: true),
 booleanParam(defaultValue: true, description: 'Deploy mig operator using OLM on OCP4', name: 'USE_OLM'),
-booleanParam(defaultValue: false, description: 'Deploy using downstream images', name: 'MIG_OPERATOR_USE_DOWNSTREAM'),
+booleanParam(defaultValue: false, description: 'Deploy using downstream images', name: 'USE_DOWNSTREAM'),
 booleanParam(defaultValue: false, description: 'Enable debugging', name: 'DEBUG'),
 booleanParam(defaultValue: true, description: 'Clean up workspace after build', name: 'CLEAN_WORKSPACE')])])
 

--- a/pipeline/mig-e2e-base.groovy
+++ b/pipeline/mig-e2e-base.groovy
@@ -13,11 +13,7 @@ string(defaultValue: 'https://github.com/fusor/mig-e2e.git', description: 'Mig e
 string(defaultValue: 'master', description: 'Mig e2e repo branch to test', name: 'MIG_E2E_BRANCH', trim: false),
 string(defaultValue: 'e2e_mig_samples.yml', description: 'e2e test playbook to run, see https://github.com/fusor/mig-e2e for details', name: 'E2E_PLAY', trim: false),
 string(defaultValue: 'all', description: 'e2e test tags to run, see https://github.com/fusor/mig-e2e for details, space delimited', name: 'E2E_TESTS', trim: false),
-string(defaultValue: 'latest', description: 'Mig operator version/tag to deploy', name: 'MIG_OPERATOR_TAG', trim: false),
-string(defaultValue: 'latest', description: 'Mig controller version/tag to deploy', name: 'MIG_CONTROLLER_TAG', trim: false),
-string(defaultValue: 'latest', description: 'Mig ui version/tag to deploy', name: 'MIG_UI_TAG', trim: false),
-string(defaultValue: 'latest', description: 'Mig velero version/tag to deploy', name: 'MIG_VELERO_TAG', trim: false),
-string(defaultValue: 'latest', description: 'Mig velero plugin version/tag to deploy', name: 'MIG_VELERO_PLUGIN_TAG', trim: false),
+string(defaultValue: 'latest', description: 'Mig Operator/CAM release to deploy', name: 'MIG_OPERATOR_RELEASE', trim: false),
 string(defaultValue: 'scripts/mig_debug.sh', description: 'Relative file path to debug script on MIG CI repo', name: 'DEBUG_SCRIPT', trim: false),
 string(defaultValue: '', description: 'Extra debug script arguments', name: 'DEBUG_SCRIPT_ARGS', trim: false),
 string(defaultValue: 'quay.io/fbladilo/mig-controller', description: 'Repo for quay io for custom mig-controller images, only used by GHPRB', name: 'QUAYIO_CI_REPO', trim: false),
@@ -27,11 +23,15 @@ credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.StringC
 credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.UsernamePasswordMultiBinding', defaultValue: 'ci_ocp4_admin_credentials', description: 'Cluster admin credentials used in OCP4 deployments', name: 'OCP4_CREDENTIALS', required: true),
 credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.UsernamePasswordMultiBinding', defaultValue: 'ci_ocp3_admin_credentials', description: 'Cluster admin credentials used in OCP3 deployments', name: 'OCP3_CREDENTIALS', required: true),
 booleanParam(defaultValue: true, description: 'Deploy mig operator using OLM on OCP4', name: 'USE_OLM'),
+booleanParam(defaultValue: false, description: 'Deploy using downstream images', name: 'USE_DOWNSTREAM'),
 booleanParam(defaultValue: false, description: 'Enable debugging', name: 'DEBUG'),
 booleanParam(defaultValue: true, description: 'Clean up workspace after build', name: 'CLEAN_WORKSPACE')])])
 
+
 // true/false build parameter that defines if we use OLM to deploy mig operator on OCP4
 USE_OLM = params.USE_OLM
+// true/false build parameter that defines if we will deploy CAM/controller using downstream images
+USE_DOWNSTREAM = params.USE_DOWNSTREAM
 // true/false build parameter that defines if we cleanup workspace once build is done
 def CLEAN_WORKSPACE = params.CLEAN_WORKSPACE
 // Split e2e tests from string param

--- a/pipeline/ocp3-base.groovy
+++ b/pipeline/ocp3-base.groovy
@@ -24,7 +24,7 @@ credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.StringC
 credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl', defaultValue: 'ci_rhel_sub_pass', description: 'RHEL Openshift subscription account password', name: 'EC2_SUB_PASS', required: true),
 credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.FileCredentialsImpl', defaultValue: 'ci_pull_secret', description: 'Pull secret needed for OCP4 deployments', name: 'OCP4_PULL_SECRET', required: true),
 credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.UsernamePasswordMultiBinding', defaultValue: 'ci_ocp3_admin_credentials', description: 'Cluster admin credentials used in OCP3 deployments', name: 'OCP3_CREDENTIALS', required: true),
-booleanParam(defaultValue: false, description: 'Update OCP3 cluster packages to latest', name: 'OCP3_UPDATE'),
+booleanParam(defaultValue: true, description: 'Update OCP3 cluster packages to latest', name: 'OCP3_UPDATE'),
 booleanParam(defaultValue: true, description: 'Provision glusterfs workload on OCP3', name: 'OCP3_GLUSTERFS'),
 booleanParam(defaultValue: false, description: 'Persistent cluster builds with fixed hostname', name: 'PERSISTENT'),
 booleanParam(defaultValue: true, description: 'Clean up workspace after build', name: 'CLEAN_WORKSPACE'),

--- a/pipeline/parallel-base.groovy
+++ b/pipeline/parallel-base.groovy
@@ -27,12 +27,7 @@ string(defaultValue: 'https://github.com/fusor/mig-e2e.git', description: 'Mig e
 string(defaultValue: 'master', description: 'Mig e2e repo branch to test', name: 'MIG_E2E_BRANCH', trim: false),
 string(defaultValue: 'e2e_mig_samples.yml', description: 'e2e test playbook to run, see https://github.com/fusor/mig-e2e for details', name: 'E2E_PLAY', trim: false),
 string(defaultValue: 'all', description: 'e2e test tags to run, see https://github.com/fusor/mig-e2e for details, space delimited', name: 'E2E_TESTS', trim: false),
-string(defaultValue: 'latest', description: 'Mig operator version/tag to deploy', name: 'MIG_OPERATOR_TAG', trim: false),
-string(defaultValue: 'latest', description: 'Mig controller version/tag to deploy', name: 'MIG_CONTROLLER_TAG', trim: false),
-string(defaultValue: 'latest', description: 'Mig ui version/tag to deploy', name: 'MIG_UI_TAG', trim: false),
-string(defaultValue: 'latest', description: 'Mig velero version/tag to deploy', name: 'MIG_VELERO_TAG', trim: false),
-string(defaultValue: 'latest', description: 'Mig velero plugin version/tag to deploy', name: 'MIG_VELERO_PLUGIN_TAG', trim: false),
-string(defaultValue: 'latest', description: 'Mig velero restic restore helper version/tag to deploy', name: 'MIG_VELERO_RESTIC_RESTORE_HELPER_TAG', trim: false),
+string(defaultValue: 'latest', description: 'Mig Operator/CAM release to deploy', name: 'MIG_OPERATOR_RELEASE', trim: false),
 string(defaultValue: 'scripts/mig_debug.sh', description: 'Relative file path to debug script on MIG CI repo', name: 'DEBUG_SCRIPT', trim: false),
 string(defaultValue: '', description: 'Extra debug script arguments', name: 'DEBUG_SCRIPT_ARGS', trim: false),
 string(defaultValue: 'quay.io/fbladilo/mig-controller', description: 'Repo for quay io for custom mig-controller images, only used by GHPRB', name: 'QUAYIO_CI_REPO', trim: false),
@@ -48,10 +43,11 @@ credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.FileCre
 credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.UsernamePasswordMultiBinding', defaultValue: 'ci_ocp4_admin_credentials', description: 'Cluster admin credentials used in OCP4 deployments', name: 'OCP4_CREDENTIALS', required: true),
 credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.UsernamePasswordMultiBinding', defaultValue: 'ci_ocp3_admin_credentials', description: 'Cluster admin credentials used in OCP3 deployments', name: 'OCP3_CREDENTIALS', required: true),
 booleanParam(defaultValue: true, description: 'Run e2e tests', name: 'E2E_RUN'),
-booleanParam(defaultValue: false, description: 'Update OCP3 cluster packages to latest', name: 'OCP3_UPDATE'),
+booleanParam(defaultValue: true, description: 'Update OCP3 cluster packages to latest', name: 'OCP3_UPDATE'),
 booleanParam(defaultValue: true, description: 'Provision glusterfs workload on OCP3', name: 'OCP3_GLUSTERFS'),
 booleanParam(defaultValue: true, description: 'Provision CEPH workload on destination cluster', name: 'CEPH'),
 booleanParam(defaultValue: true, description: 'Deploy mig operator using OLM on OCP4', name: 'USE_OLM'),
+booleanParam(defaultValue: false, description: 'Deploy using downstream images', name: 'USE_DOWNSTREAM'),
 booleanParam(defaultValue: true, description: 'Clean up workspace after build', name: 'CLEAN_WORKSPACE'),
 booleanParam(defaultValue: false, description: 'Persistent cluster builds with fixed hostname', name: 'PERSISTENT'),
 booleanParam(defaultValue: false, description: 'Enable debugging', name: 'DEBUG'),
@@ -59,6 +55,8 @@ booleanParam(defaultValue: true, description: 'EC2 terminate instances after bui
 
 // true/false build parameter that defines if we use OLM to deploy mig operator on OCP4
 USE_OLM = params.USE_OLM
+// true/false build parameter that defines if we will deploy CAM/controller using downstream images
+USE_DOWNSTREAM = params.USE_DOWNSTREAM
 // true/false build parameter that defines if we terminate instances once build is done
 def EC2_TERMINATE_INSTANCES = params.EC2_TERMINATE_INSTANCES
 // true/false build parameter that defines if we cleanup workspace once build is done

--- a/pipeline/parallel-base.groovy
+++ b/pipeline/parallel-base.groovy
@@ -47,7 +47,7 @@ booleanParam(defaultValue: true, description: 'Update OCP3 cluster packages to l
 booleanParam(defaultValue: true, description: 'Provision glusterfs workload on OCP3', name: 'OCP3_GLUSTERFS'),
 booleanParam(defaultValue: true, description: 'Provision CEPH workload on destination cluster', name: 'CEPH'),
 booleanParam(defaultValue: true, description: 'Deploy mig operator using OLM on OCP4', name: 'USE_OLM'),
-booleanParam(defaultValue: false, description: 'Deploy using downstream images', name: 'USE_DOWNSTREAM'),
+booleanParam(defaultValue: false, description: 'Deploy using downstream images', name: 'MIG_OPERATOR_USE_DOWNSTREAM'),
 booleanParam(defaultValue: true, description: 'Clean up workspace after build', name: 'CLEAN_WORKSPACE'),
 booleanParam(defaultValue: false, description: 'Persistent cluster builds with fixed hostname', name: 'PERSISTENT'),
 booleanParam(defaultValue: false, description: 'Enable debugging', name: 'DEBUG'),
@@ -55,8 +55,6 @@ booleanParam(defaultValue: true, description: 'EC2 terminate instances after bui
 
 // true/false build parameter that defines if we use OLM to deploy mig operator on OCP4
 USE_OLM = params.USE_OLM
-// true/false build parameter that defines if we will deploy CAM/controller using downstream images
-USE_DOWNSTREAM = params.USE_DOWNSTREAM
 // true/false build parameter that defines if we terminate instances once build is done
 def EC2_TERMINATE_INSTANCES = params.EC2_TERMINATE_INSTANCES
 // true/false build parameter that defines if we cleanup workspace once build is done

--- a/pipeline/parallel-base.groovy
+++ b/pipeline/parallel-base.groovy
@@ -47,7 +47,7 @@ booleanParam(defaultValue: true, description: 'Update OCP3 cluster packages to l
 booleanParam(defaultValue: true, description: 'Provision glusterfs workload on OCP3', name: 'OCP3_GLUSTERFS'),
 booleanParam(defaultValue: true, description: 'Provision CEPH workload on destination cluster', name: 'CEPH'),
 booleanParam(defaultValue: true, description: 'Deploy mig operator using OLM on OCP4', name: 'USE_OLM'),
-booleanParam(defaultValue: false, description: 'Deploy using downstream images', name: 'MIG_OPERATOR_USE_DOWNSTREAM'),
+booleanParam(defaultValue: false, description: 'Deploy using downstream images', name: 'USE_DOWNSTREAM'),
 booleanParam(defaultValue: true, description: 'Clean up workspace after build', name: 'CLEAN_WORKSPACE'),
 booleanParam(defaultValue: false, description: 'Persistent cluster builds with fixed hostname', name: 'PERSISTENT'),
 booleanParam(defaultValue: false, description: 'Enable debugging', name: 'DEBUG'),

--- a/roles/mig_controller_deploy/tasks/check.yml
+++ b/roles/mig_controller_deploy/tasks/check.yml
@@ -5,7 +5,7 @@
     label_selectors: "component=velero"
   register: pod
   until: "true in (pod | json_query('resources[].status.containerStatuses[].ready'))"
-  retries: 12
+  retries: 30
   delay: 10
   when: mig_controller_velero|bool
 
@@ -16,7 +16,7 @@
     label_selectors: "name=restic"
   register: pod
   until: "true in (pod | json_query('resources[].status.containerStatuses[].ready'))"
-  retries: 12
+  retries: 30
   delay: 10
   when: mig_controller_velero|bool
 
@@ -27,6 +27,6 @@
     label_selectors: "control-plane=controller-manager"
   register: pod
   until: "true in (pod | json_query('resources[].status.containerStatuses[].ready'))"
-  retries: 12
+  retries: 30
   delay: 10
   when: mig_controller_host_cluster|bool

--- a/roles/mig_controller_deploy/tasks/deploy.yml
+++ b/roles/mig_controller_deploy/tasks/deploy.yml
@@ -1,13 +1,7 @@
 - debug:
-    msg: |
-         Mig controller will deploy using: 
-         {{ mig_controller_img }}:{{ mig_controller_tag }}
-         {{ mig_ui_img }}:{{ mig_ui_tag }}
-         {{ mig_velero_img }}:{{ mig_velero_tag }}
-         {{ mig_velero_plugin_img }}:{{ mig_velero_plugin_tag }}
-         {{ mig_velero_restic_restore_helper_img }}:{{ mig_velero_restic_restore_helper_tag }}
+    msg: "Mig controller will deploy using release: {{ mig_operator_release }}"
 
-- name: Deploying mig contoller using OLM
+- name: Deploying mig controller using OLM
   block:
 
     - name: Include required vars
@@ -15,7 +9,7 @@
       vars:
         olm_files:
           - "{{ playbook_dir }}/olm/olm_vars.yml"
-          - "{{ playbook_dir }}/roles/mig_controller_prereqs/defaults/olm_vars.yml"
+          - "{{ playbook_dir }}/roles/mig_controller_deploy/defaults/olm_vars.yml"
     
     - debug:
         msg: "OLM cluster version: {{ olm_cluster_version }}"

--- a/roles/mig_controller_deploy/templates/controller.yml.j2
+++ b/roles/mig_controller_deploy/templates/controller.yml.j2
@@ -13,26 +13,10 @@ spec:
   mig_pv_limit: {{ mig_controller_mig_pv_limit }}
   mig_pod_limit: {{ mig_controller_mig_pod_limit }}
   mig_namespace_limit: {{ mig_controller_mig_namespace_limit }}
-  mig_controller_image: {{ mig_controller_img }}
-  mig_controller_version: {{ mig_controller_tag }}
-  mig_ui_image: {{ mig_ui_img }}
-{% if mig_operator_tag == 'stable' and mig_operator_use_olm is sameas true %}
-  snapshot_tag: {{ mig_operator_tag }}
-{% endif %}
 {% if olm_cluster_version is defined %}
 {% if '4.1' in olm_cluster_version|string %}
   deprecated_cors_configuration: true
 {% endif %}
 {% endif %}
-  mig_ui_version: {{ mig_ui_tag }}
-  velero_image: {{ mig_velero_img }}
-  velero_version: {{ mig_velero_tag }}
-  velero_plugin_image: {{ mig_velero_plugin_img }}
-  velero_plugin_version: {{ mig_velero_plugin_tag }}
-  velero_restic_restore_helper_image: {{ mig_velero_restic_restore_helper_img }}
-  velero_restic_restore_helper_version: {{ mig_velero_restic_restore_helper_tag }}
-
-  mig_ui_config_namespace: {{ mig_migration_namespace }}
-  
   #To install the controller on Openshift 3 you will need to configure the API endpoint:
   #mig_ui_cluster_api_endpoint: https://replace-with-openshift-cluster-hostname:8443

--- a/roles/mig_controller_prereqs/defaults/main.yml
+++ b/roles/mig_controller_prereqs/defaults/main.yml
@@ -2,26 +2,19 @@
 mig_operator_location: "{{ workspace }}/mig-operator"
 mig_operator_repo: "{{ lookup('env', 'MIG_OPERATOR_REPO') or 'https://github.com/fusor/mig-operator.git' }}"
 mig_operator_branch: "{{ lookup('env', 'MIG_OPERATOR_BRANCH') or 'master' }}"
+mig_operator_release: "{{ lookup('env', 'MIG_OPERATOR_RELEASE') or 'latest' }}"
+mig_operator_use_olm: "{{ lookup('env', 'MIG_OPERATOR_USE_OLM') or 'false' }}"
+mig_operator_use_downstream: "{{ lookup('env', 'MIG_OPERATOR_USE_DOWNSTREAM') or 'false' }}"
+mig_operator_selector: { '4.1': 'marketplace.catalogSourceConfig=ocpmigrate-operators', '4.2': 'marketplace.operatorSource=ocpmigrate-operators', 'nightly': 'marketplace.operatorSource=ocpmigrate-operators', '4.3': 'marketplace.operatorSource=ocpmigrate-operators', 'latest-4.1': 'marketplace.catalogSourceConfig=ocpmigrate-operators', 'latest-4.2': 'marketplace.operatorSource=ocpmigrate-operators', 'latest': 'marketplace.operatorSource=ocpmigrate-operators' }
+mig_operator_label_selector: { 'v1.0.0': 'migration-operator', 'v1.0.1': 'migration-operator', 'latest': 'migration' }
 mig_controller_location: "{{ workspace }}/mig-controller"
 mig_controller_repo: "{{ lookup('env', 'MIG_CONTROLLER_REPO') or 'https://github.com/fusor/mig-controller.git' }}"
 mig_controller_branch: "{{ lookup('env', 'MIG_CONTROLLER_BRANCH') or 'master' }}"
-mig_controller_img: "{{ lookup('env', 'MIG_CONTROLLER_IMG') or 'quay.io/ocpmigrate/mig-controller' }}"
-mig_controller_tag: "{{ lookup('env', 'MIG_CONTROLLER_TAG') or 'latest' }}"
-mig_operator_img: "{{ lookup('env', 'MIG_OPERATOR_IMG') or 'quay.io/ocpmigrate/mig-operator' }}"
-mig_operator_tag: "{{ lookup('env', 'MIG_OPERATOR_TAG') or 'latest' }}"
-mig_operator_use_olm: "{{ lookup('env', 'MIG_OPERATOR_USE_OLM') or 'false' }}"
-mig_operator_selector: { '4.1': 'marketplace.catalogSourceConfig=ocpmigrate-operators', '4.2': 'marketplace.operatorSource=ocpmigrate-operators', 'nightly': 'marketplace.operatorSource=ocpmigrate-operators', '4.3': 'marketplace.operatorSource=ocpmigrate-operators', 'latest-4.1': 'marketplace.catalogSourceConfig=ocpmigrate-operators', 'latest-4.2': 'marketplace.operatorSource=ocpmigrate-operators', 'latest': 'marketplace.operatorSource=ocpmigrate-operators' }
-mig_ui_img: "{{ lookup('env', 'MIG_UI_IMG') or 'quay.io/ocpmigrate/mig-ui' }}"
-mig_ui_tag: "{{ lookup('env', 'MIG_UI_TAG') or 'latest' }}"
-mig_velero_img: "{{ lookup('env', 'MIG_VELERO_IMG') or 'quay.io/ocpmigrate/velero' }}"
-mig_velero_tag: "{{ lookup('env', 'MIG_VELERO_TAG') or 'latest' }}"
-mig_velero_plugin_img: "{{ lookup('env', 'MIG_VELERO_PLUGIN_IMG') or 'quay.io/ocpmigrate/migration-plugin' }}"
-mig_velero_plugin_tag: "{{ lookup('env', 'MIG_VELERO_PLUGIN_TAG') or 'latest' }}"
-mig_velero_restic_restore_helper_img: "{{ lookup('env', 'MIG_VELERO_RESTIC_RESTORE_HELPER_IMG') or 'quay.io/ocpmigrate/velero-restic-restore-helper' }}"
-mig_velero_restic_restore_helper_tag: "{{ lookup('env', 'MIG_VELERO_RESTIC_RESTORE_HELPER_TAG') or 'latest' }}"
 mig_controller_sa_name: mig
 mig_controller_host_cluster: true
 mig_controller_velero: true
 mig_controller_ui: true
 mig_controller_remote_cluster_online: true
 mig_migration_namespace: openshift-migration
+rh_sub_user: "{{ lookup('env', 'SUB_USER') }}"
+rh_sub_pass: "{{ lookup('env', 'SUB_PASS') }}"

--- a/roles/mig_controller_prereqs/tasks/deploy_operator.yml
+++ b/roles/mig_controller_prereqs/tasks/deploy_operator.yml
@@ -11,95 +11,25 @@
   ignore_errors: true
   when: not op_repo.stat.exists
 
+- assert:
+    that:
+      - mig_operator_release != 'latest'
+    fail_msg: "latest is not a valid release for downstream CAM deployments"
+  when: mig_operator_use_downstream|bool
+
 - debug:
     msg: 
-      - "Mig operator will deploy using OLM : {{ mig_operator_use_olm }}"
-      - "Mig operator will deploy using release : {{ mig_operator_tag }}"
+      - "Operator will deploy using OLM : {{ mig_operator_use_olm }}"
+      - "Operator use downstream release : {{ mig_operator_use_downstream }}"
+      - "Operator will deploy using release : {{ mig_operator_release }}"
 
-- name: "Deploy mig operator using OLM"
-  block:
+- name: "Deploy using OLM operator"
+  import_tasks: operator_olm.yml
+  when: mig_operator_use_olm|bool
 
-    - name: "Include required vars"
-      include_vars:  "{{ lookup('first_found', olm_files) }}"
-      vars:
-        olm_files:
-          - "{{ playbook_dir }}/olm/olm_vars.yml"
-          - "{{ playbook_dir }}/roles/mig_controller_prereqs/defaults/olm_vars.yml"
-    
-    - debug:
-        msg: 
-          - "OLM cluster version: {{ olm_cluster_version }}"
-          - "Using mig operator selector: {{ mig_operator_selector[olm_cluster_version] }}"
+- name: "Deploy using non-OLM operator"
+  import_tasks: operator_non_olm.yml
+  when: not mig_operator_use_olm|bool
 
-    - name: "Create OperatorSource"
-      k8s:
-        state: present
-        definition: "{{ lookup('file', '{{ mig_operator_location }}/mig-operator-source.yaml' )}}"
-      register: mig_operator_source_created
-      until: mig_operator_source_created is succeeded
-      retries: 30
-      delay: 30
-
-    - name: "Wait for OLM to reconcile OperatorSource creation"
-      k8s_facts:
-        kind: Pod
-        namespace: openshift-marketplace
-        label_selectors: "{{ mig_operator_selector[olm_cluster_version] }}"
-      register: pod
-      until: pod.get("resources", []) | length > 0 and true in (pod | json_query('resources[].status.containerStatuses[].ready'))
-      retries: 15
-      delay: 12
-
-    - name: "Confirm service availability"
-      k8s_facts:
-        kind: Service
-        namespace: openshift-marketplace
-        name: ocpmigrate-operators
-        label_selectors: "marketplace.catalogSourceConfig=ocpmigrate-operators"
-      register: service
-      until: "'grpc' in (service | json_query('resources[].spec.ports[].name'))"
-      retries: 15
-      delay: 12
-
-    - name: "Create {{ mig_migration_namespace }} namespace"
-      k8s:
-        name: "{{ mig_migration_namespace }}"
-        kind: Namespace
-        state: present
-      
-    - name: "Get grpc_endpoint IP:port of ocpmigrate-operators service"
-      set_fact:
-        grpc_endpoint: "{{ service | json_query('resources[0].spec.clusterIP') }}:{{ service | json_query('resources[0].spec.ports[0].port') }}"
-
-    - name: "Create CatalogSource"
-      k8s:
-        state: present
-        definition: "{{ lookup('template', 'mig-operator-catalogsource.yml.j2' ) }}"
-
-    - name: "Create OperatorGroup"
-      k8s:
-        state: present
-        definition: "{{ lookup('template', 'mig-operator-operatorgroup.yml.j2' ) }}"
-
-    - name: "Create Subscription"
-      k8s:
-        state: present
-        definition: "{{ lookup('template', 'mig-operator-subscription.yml.j2' ) }}"
-
-  when: mig_operator_use_olm|bool 
-      
-- name: "Deploy mig operator"
-  k8s:
-    state : present
-    definition: "{{ lookup('file', '{{ mig_operator_location }}/deploy/non-olm/{{ mig_operator_tag }}/operator.yml' )}}"
-  when: not mig_operator_use_olm|bool 
-
-- name: "Check status of mig operator"
-  k8s_facts:
-    kind: Pod
-    namespace: "{{ mig_migration_namespace }}"
-    label_selectors: "app=migration-operator"
-  register: pod
-  until: pod.get("resources", []) | length > 0 and true in (pod | json_query('resources[].status.containerStatuses[].ready'))
-  retries: 60
-  delay: 15
+- name: "Check operator status"
+  import_tasks: operator_check.yml

--- a/roles/mig_controller_prereqs/tasks/operator_check.yml
+++ b/roles/mig_controller_prereqs/tasks/operator_check.yml
@@ -1,0 +1,10 @@
+---
+- name: "Check status of mig operator"
+  k8s_facts:
+    kind: Pod
+    namespace: "{{ mig_migration_namespace }}"
+    label_selectors: "app={{ mig_operator_label_selector[mig_operator_release] }}"
+  register: pod
+  until: pod.get("resources", []) | length > 0 and true in (pod | json_query('resources[].status.containerStatuses[].ready'))
+  retries: 60
+  delay: 15

--- a/roles/mig_controller_prereqs/tasks/operator_downstream_non_olm.yml
+++ b/roles/mig_controller_prereqs/tasks/operator_downstream_non_olm.yml
@@ -1,0 +1,36 @@
+---
+
+- assert:
+    that:
+      - rh_sub_user != ''
+      - rh_sub_pass != ''
+    fail_msg: "rh_sub_user and rh_sub_pass variables must be set for podman based CAM deployments"
+
+- name: "Deploy CAM downstream operator using podman"
+  block:
+    - name: "Login to {{ rh_registry }}"
+      shell: "podman login registry.redhat.io -u {{ rh_sub_user }} -p {{ rh_sub_pass }}"
+
+    - name: "Prepare CAM downstream image"
+      shell: "podman create registry.redhat.io/rhcam-1-0/openshift-migration-rhel7-operator:v1.0"
+      register: podman_create
+
+    - name: "Extract operator.yml from CAM downstream image"
+      shell: "podman cp {{ podman_create.stdout }}:/operator.yml {{ playbook_dir }}"
+
+    - name: "Extract controller-3.yml from CAM downstream image"
+      shell: "podman cp {{ podman_create.stdout }}:/controller-3.yml {{ playbook_dir }}"
+       
+    - name: "Update ownership of extracted files"
+      file:
+        path: "{{ item }}"
+        owner: "{{ ansible_user }}"
+      loop: 
+        - "{{ playbook_dir }}/operator.yml"
+        - "{{ playbook_dir }}/controller-3.yml"
+  become: true
+
+- name: "Create CAM downstream operator"
+  k8s:
+    state: present
+    definition: "{{ lookup('file', '{{ playbook_dir }}/operator.yml' ) }}"

--- a/roles/mig_controller_prereqs/tasks/operator_downstream_non_olm.yml
+++ b/roles/mig_controller_prereqs/tasks/operator_downstream_non_olm.yml
@@ -8,7 +8,7 @@
 
 - name: "Deploy CAM downstream operator using podman"
   block:
-    - name: "Login to {{ rh_registry }}"
+    - name: "Login to RH registry"
       shell: "podman login registry.redhat.io -u {{ rh_sub_user }} -p {{ rh_sub_pass }}"
 
     - name: "Prepare CAM downstream image"
@@ -28,6 +28,10 @@
       loop: 
         - "{{ playbook_dir }}/operator.yml"
         - "{{ playbook_dir }}/controller-3.yml"
+
+    - name: "Clean up podman image cache"
+      shell: "podman rmi -af"
+
   become: true
 
 - name: "Create CAM downstream operator"

--- a/roles/mig_controller_prereqs/tasks/operator_downstream_olm.yml
+++ b/roles/mig_controller_prereqs/tasks/operator_downstream_olm.yml
@@ -1,0 +1,29 @@
+- name: "Deploy downstream mig operator using OLM"
+  block:
+
+    - name: "Include required vars"
+      include_vars:  "{{ lookup('first_found', olm_files) }}"
+      vars:
+        olm_files:
+          - "{{ playbook_dir }}/olm/olm_vars.yml"
+          - "{{ playbook_dir }}/roles/mig_controller_deploy/defaults/olm_vars.yml"
+
+    - debug:
+        msg:
+          - "OLM cluster version: {{ olm_cluster_version }}"
+
+    - name: "Create {{ mig_migration_namespace }} namespace"
+      k8s:
+        name: "{{ mig_migration_namespace }}"
+        kind: Namespace
+        state: present
+
+    - name: "Create OperatorGroup"
+      k8s:
+        state: present
+        definition: "{{ lookup('template', 'mig-operator-operatorgroup.yml.j2' ) }}"
+
+    - name: "Create operator subscription"
+      k8s:
+        state: present
+        definition: "{{ lookup('template', 'mig-operator-subscription-downstream.yml.j2' ) }}"

--- a/roles/mig_controller_prereqs/tasks/operator_non_olm.yml
+++ b/roles/mig_controller_prereqs/tasks/operator_non_olm.yml
@@ -1,0 +1,9 @@
+---
+
+- name: "Deploy using non-OLM upstream operator"
+  import_tasks: operator_upstream_non_olm.yml
+  when: not mig_operator_use_downstream|bool
+
+- name: "Deploy using non-OLM downstream operator"
+  import_tasks: operator_downstream_non_olm.yml
+  when: mig_operator_use_downstream|bool

--- a/roles/mig_controller_prereqs/tasks/operator_olm.yml
+++ b/roles/mig_controller_prereqs/tasks/operator_olm.yml
@@ -1,0 +1,9 @@
+---
+
+- name: "Deploy using OLM upstream operator"
+  import_tasks: operator_upstream_olm.yml
+  when: not mig_operator_use_downstream|bool
+
+- name: "Deploy using OLM downstream operator"
+  import_tasks: operator_downstream_olm.yml
+  when: mig_operator_use_downstream|bool

--- a/roles/mig_controller_prereqs/tasks/operator_upstream_non_olm.yml
+++ b/roles/mig_controller_prereqs/tasks/operator_upstream_non_olm.yml
@@ -1,0 +1,5 @@
+---
+- name: "Deploy non-olm mig upstream operator"
+  k8s:
+    state : present
+    definition: "{{ lookup('file', '{{ mig_operator_location }}/deploy/non-olm/{{ mig_operator_release }}/operator.yml' )}}"

--- a/roles/mig_controller_prereqs/tasks/operator_upstream_olm.yml
+++ b/roles/mig_controller_prereqs/tasks/operator_upstream_olm.yml
@@ -29,6 +29,8 @@
         label_selectors: "{{ mig_operator_selector[olm_cluster_version] }}"
       register: pod
       until: pod.get("resources", []) | length > 0 and true in (pod | json_query('resources[].status.containerStatuses[].ready'))
+      retries: 18
+      delay: 10
 
     - name: "Confirm service availability"
       k8s_facts:
@@ -38,8 +40,8 @@
         label_selectors: "marketplace.catalogSourceConfig=ocpmigrate-operators"
       register: service
       until: "'grpc' in (service | json_query('resources[].spec.ports[].name'))"
-      retries: 15
-      delay: 12
+      retries: 18
+      delay: 10
 
     - name: "Create {{ mig_migration_namespace }} namespace"
       k8s:

--- a/roles/mig_controller_prereqs/tasks/operator_upstream_olm.yml
+++ b/roles/mig_controller_prereqs/tasks/operator_upstream_olm.yml
@@ -1,0 +1,67 @@
+- name: "Deploy upstream mig operator using OLM"
+  block:
+
+    - name: "Include required vars"
+      include_vars:  "{{ lookup('first_found', olm_files) }}"
+      vars:
+        olm_files:
+          - "{{ playbook_dir }}/olm/olm_vars.yml"
+          - "{{ playbook_dir }}/roles/mig_controller_deploy/defaults/olm_vars.yml"
+
+    - debug:
+        msg:
+          - "OLM cluster version: {{ olm_cluster_version }}"
+          - "Using mig operator selector: {{ mig_operator_selector[olm_cluster_version] }}"
+
+    - name: "Create OperatorSource"
+      k8s:
+        state: present
+        definition: "{{ lookup('file', '{{ mig_operator_location }}/mig-operator-source.yaml' )}}"
+      register: mig_operator_source_created
+      until: mig_operator_source_created is succeeded
+      retries: 30
+      delay: 30
+
+    - name: "Wait for OLM to reconcile OperatorSource creation"
+      k8s_facts:
+        kind: Pod
+        namespace: openshift-marketplace
+        label_selectors: "{{ mig_operator_selector[olm_cluster_version] }}"
+      register: pod
+      until: pod.get("resources", []) | length > 0 and true in (pod | json_query('resources[].status.containerStatuses[].ready'))
+
+    - name: "Confirm service availability"
+      k8s_facts:
+        kind: Service
+        namespace: openshift-marketplace
+        name: ocpmigrate-operators
+        label_selectors: "marketplace.catalogSourceConfig=ocpmigrate-operators"
+      register: service
+      until: "'grpc' in (service | json_query('resources[].spec.ports[].name'))"
+      retries: 15
+      delay: 12
+
+    - name: "Create {{ mig_migration_namespace }} namespace"
+      k8s:
+        name: "{{ mig_migration_namespace }}"
+        kind: Namespace
+        state: present
+
+    - name: "Get grpc_endpoint IP:port of ocpmigrate-operators service"
+      set_fact:
+        grpc_endpoint: "{{ service | json_query('resources[0].spec.clusterIP') }}:{{ service | json_query('resources[0].spec.ports[0].port') }}"
+
+    - name: "Create CatalogSource"
+      k8s:
+        state: present
+        definition: "{{ lookup('template', 'mig-operator-catalogsource.yml.j2' ) }}"
+
+    - name: "Create OperatorGroup"
+      k8s:
+        state: present
+        definition: "{{ lookup('template', 'mig-operator-operatorgroup.yml.j2' ) }}"
+
+    - name: "Create Subscription"
+      k8s:
+        state: present
+        definition: "{{ lookup('template', 'mig-operator-subscription.yml.j2' ) }}"

--- a/roles/mig_controller_prereqs/templates/mig-operator-subscription-downstream.yml.j2
+++ b/roles/mig_controller_prereqs/templates/mig-operator-subscription-downstream.yml.j2
@@ -1,0 +1,12 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: cam-operator
+  namespace: {{ mig_migration_namespace }}
+spec:
+  channel: release-v1
+  installPlanApproval: Automatic
+  name: cam-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  startingCSV: cam-operator.{{ mig_operator_release }}

--- a/roles/mig_controller_prereqs/templates/mig-operator-subscription.yml.j2
+++ b/roles/mig_controller_prereqs/templates/mig-operator-subscription.yml.j2
@@ -4,17 +4,13 @@ metadata:
   name: mig-operator
   namespace: {{ mig_migration_namespace }}
 spec:
-{% if mig_operator_tag == 'v1.0.0' %}
-  channel: release-v1
+{% if mig_operator_release == 'latest' %}
+  channel: {{ mig_operator_release }}
 {% else %}
-  channel: {{ mig_operator_tag }}
+  channel: release-v1
 {% endif %}
   installPlanApproval: Automatic
   name: mig-operator
   source: installed-custom-openshift-migration
   sourceNamespace: {{ mig_migration_namespace }}
-{% if mig_operator_tag == 'release-v1' %}
-  startingCSV: mig-operator.v1.0.0
-{% else %}
-  startingCSV: mig-operator.{{ mig_operator_tag }}
-{% endif %}
+  startingCSV: mig-operator.{{ mig_operator_release }}


### PR DESCRIPTION
This PR does a few things, most notably adding the ability to test downstream GA images, below is a summary of deployment scenarios for CAM/controller that will possible now : 

**Non-OLM :** 
- upstream (OCPv3) : latest, release-v1 (v1.0.0 and v1.0.1 for now)
- upstream (OCPv4) : latest, release-v1
- downstream (OCPv3) : release-v1(v1.0.1 via podman)

**OLM (OCPv4 only) :** 
- upstream : latest and release-v1 (v1.0.0 and v1.0.1 for now)
- downstream : release-v1 (v1.0.0 breaks, only v1.0.1 succeeding)

**Note : latest is not a valid release or channel on downstream builds, it does not exist.**

**Other consideration and changes on this PR :** 

- We do not use image locations or tags any longer when creating the controller CR, the operator defaults for each will apply
- Downstream deployments are controller by MIG_OPERATOR_USE_DOWNSTREAM boolean parameter on pipeline
- The tested CAM/controller version is controlled by MIG_OPERATOR_RELEASE
- Switched OCP3_UPDATE to default true on parallel-base (3 OCPv3 releases actually need the updates)
- Downstream releases only support OCP v3.11 at the moment, older releases will need extra automation to allow registry.redhat.io to be configured prior attempting operator deployments
