### PR TITLE
Disable failfast on parallel base pipeline deploy

### DIFF
--- a/pipeline/parallel-base.groovy
+++ b/pipeline/parallel-base.groovy
@@ -119,7 +119,7 @@ node {
                   common_stages.deploy_ceph(DEST_CLUSTER_VERSION).call()
                     }
             },
-            failFast: true
+            failFast: false
         }
 
        common_stages.deploy_mig_controller_on_both(SOURCE_KUBECONFIG, TARGET_KUBECONFIG, false, true).call()


### PR DESCRIPTION
- Failfast introduces cleanup issues when OCPv3 cluster deployments fail
  prematurely while OCP4 installations are still ongoing. Agnosticd fails to
destroy the OCPv4 cluster as is still progressing and has not yet failed, leaving allocated resources on AWS. 
Disabling failfast intends to yield a safer parallel cluster deploy approach, since it will let the remaining steps in the stage complete and then fail it.